### PR TITLE
Properly initializes currentTime for restart.

### DIFF
--- a/src/core/Peridigm.cpp
+++ b/src/core/Peridigm.cpp
@@ -918,6 +918,7 @@ void PeridigmNS::Peridigm::InitializeRestart() {
 	std::string str;
 	struct stat sb;
 	char const * restart_directory_namePtr;
+  currentTime = 0; // Initialize
 	if (stat("restart-000001", &sb) == 0 && S_ISDIR(sb.st_mode)){
 	    str=getCmdOutput("ls -td -- ./restart*/ | head -n1 | cut -d'/' -f2");
 	    if (str != ""){


### PR DESCRIPTION
Restart sometimes failed, because currentTime was left uninitialized and didn't match the start time i.e. 0. 