### PR TITLE
Fix Issue #148

### DIFF
--- a/src/compute/Peridigm_Compute_Energy.cpp
+++ b/src/compute/Peridigm_Compute_Energy.cpp
@@ -162,7 +162,7 @@ int PeridigmNS::Compute_Energy::compute( Teuchos::RCP< std::vector<PeridigmNS::B
         for (int j=0; j<numNeighbors; j++)
           {
             int neighborID = neighborhoodList[neighborhoodListIndex++];
-            TEUCHOS_TEST_FOR_EXCEPT_MSG(neighborID < 0, "Invalid neighbor list\n");
+            TEUCHOS_TEST_FOR_TERMINATION(neighborID < 0, "Invalid neighbor list\n");
             int Ne = neighborID;
             vol2 = volume_values[Ne];
             double psi1 = (ref_values[3*Ne] - ref_values[3*i]);

--- a/src/compute/Peridigm_Compute_Error.cpp
+++ b/src/compute/Peridigm_Compute_Error.cpp
@@ -169,17 +169,17 @@ int PeridigmNS::Compute_Error::compute( Teuchos::RCP< std::vector<PeridigmNS::Bl
       }
       bool isRectangular = (numX1 == 4 && numX2 == 4 && numY1 == 4 && numY2 == 4 && numZ1 == 4 && numZ2 == 4);
       if(!isRectangular){
-	std::stringstream ss;
-	ss << "**** Error:  Error compute class detected non-rectangular element." << std::endl;
-	for(int i=0 ; i<8 ; ++i)
-	  ss << "  (" << n[i][0] << ", " << n[i][1] << ", " << n[i][2] << ")" << std::endl;
-	ss << "  numX1 = " << numX1 << std::endl;
-	ss << "  numX2 = " << numX2 << std::endl;
-	ss << "  numY1 = " << numY1 << std::endl;
-	ss << "  numY2 = " << numY2 << std::endl;
-	ss << "  numZ1 = " << numZ1 << std::endl;
-	ss << "  numZ2 = " << numZ2 << std::endl;
-	TEUCHOS_TEST_FOR_EXCEPT_MSG(!isRectangular, ss.str());
+        std::stringstream ss;
+        ss << "**** Error:  Error compute class detected non-rectangular element." << std::endl;
+        for(int i=0 ; i<8 ; ++i)
+          ss << "  (" << n[i][0] << ", " << n[i][1] << ", " << n[i][2] << ")" << std::endl;
+        ss << "  numX1 = " << numX1 << std::endl;
+        ss << "  numX2 = " << numX2 << std::endl;
+        ss << "  numY1 = " << numY1 << std::endl;
+        ss << "  numY2 = " << numY2 << std::endl;
+        ss << "  numZ1 = " << numZ1 << std::endl;
+        ss << "  numZ2 = " << numZ2 << std::endl;
+        TEUCHOS_TEST_FOR_TERMINATION(!isRectangular, ss.str());
       }
 
       // Model coordinates for the node at the center of the element
@@ -247,8 +247,8 @@ double PeridigmNS::Compute_Error::computeError_1(double peridynamicSolutionX,
   double z2 = limitOfIntegration_Z_ub;
 
   double h = x2 - x1;
-  TEUCHOS_TEST_FOR_EXCEPT_MSG(std::abs(y2 - y1 - h) > 1.0e12, "**** Error:  Error compute class detected non-square element.");
-  TEUCHOS_TEST_FOR_EXCEPT_MSG(std::abs(z2 - z1 - h) > 1.0e12, "**** Error:  Error compute class detected non-square element.");
+  TEUCHOS_TEST_FOR_TERMINATION(std::abs(y2 - y1 - h) > 1.0e12, "**** Error:  Error compute class detected non-square element.");
+  TEUCHOS_TEST_FOR_TERMINATION(std::abs(z2 - z1 - h) > 1.0e12, "**** Error:  Error compute class detected non-square element.");
 
   double x = x1 + 0.5*(x2 - x1);
 

--- a/src/compute/Peridigm_Compute_JIntegral.cpp
+++ b/src/compute/Peridigm_Compute_JIntegral.cpp
@@ -96,7 +96,7 @@ int PeridigmNS::Compute_JIntegral::compute( Teuchos::RCP< std::vector<PeridigmNS
       block = blockIt;
     }
   }
-  TEUCHOS_TEST_FOR_EXCEPT_MSG(block == blocks->end(), "**** Error:  Compute_JIntegral, specified block_id not found.\n");
+  TEUCHOS_TEST_FOR_TERMINATION(block == blocks->end(), "**** Error:  Compute_JIntegral, specified block_id not found.\n");
 
   // Extract data for the block
   Teuchos::RCP<const PeridigmNS::Material> materialModel = block->getMaterialModel();

--- a/src/compute/Peridigm_Compute_Node_Set_Data.cpp
+++ b/src/compute/Peridigm_Compute_Node_Set_Data.cpp
@@ -70,8 +70,8 @@ PeridigmNS::Compute_Node_Set_Data::Compute_Node_Set_Data(Teuchos::RCP<const Teuc
 
   // Make sure the requested node set exists (it's really easy for a user to get confused between nodeset_1 and nodelist_1, etc.)
   std::string msg = "**** Error:  Invalid \"Node Set\" in Node_Set_Data compute class, specified node set not found.\n";
-  msg += "             Requested node set: " + m_nodeSetName + "\n";
-  msg += "             Available node sets:";
+              msg += "             Requested node set: " + m_nodeSetName + "\n";
+              msg += "             Available node sets:";
   for(std::map< std::string, std::vector<int> >::iterator it=nodeSets->begin() ; it!=nodeSets->end() ; it++)
     msg += " " + it->first;
   msg += "\n";

--- a/src/contact/Peridigm_ShortRangeForceContactModel.cpp
+++ b/src/contact/Peridigm_ShortRangeForceContactModel.cpp
@@ -133,7 +133,7 @@ PeridigmNS::ShortRangeForceContactModel::computeForce(const double dt,
       nodeVolume = cellVolume[nodeID];
       for(iNID=0 ; iNID<numNeighbors ; ++iNID){
         neighborID = contactNeighborhoodList[neighborhoodListIndex++];
-        TEUCHOS_TEST_FOR_EXCEPT_MSG(neighborID < 0, "Invalid neighbor list\n");
+        TEUCHOS_TEST_FOR_TERMINATION(neighborID < 0, "Invalid neighbor list\n");
         currentDistanceSquared =  distanceSquared(nodeCurrentX[0], nodeCurrentX[1], nodeCurrentX[2],
         y[neighborID*3], y[neighborID*3+1], y[neighborID*3+2]);
         if(currentDistanceSquared < contactRadiusSquared){

--- a/src/contact/Peridigm_UserDefinedTimeDependentShortRangeForceContactModel.cpp
+++ b/src/contact/Peridigm_UserDefinedTimeDependentShortRangeForceContactModel.cpp
@@ -181,7 +181,7 @@ PeridigmNS::UserDefinedTimeDependentShortRangeForceContactModel::computeForce(co
       nodeVolume = cellVolume[nodeID];
       for(iNID=0 ; iNID<numNeighbors ; ++iNID){
         neighborID = contactNeighborhoodList[neighborhoodListIndex++];
-        TEUCHOS_TEST_FOR_EXCEPT_MSG(neighborID < 0, "Invalid neighbor list\n");
+        TEUCHOS_TEST_FOR_TERMINATION(neighborID < 0, "Invalid neighbor list\n");
         currentDistanceSquared =  distanceSquared(nodeCurrentX[0], nodeCurrentX[1], nodeCurrentX[2],
                                                   y[neighborID*3], y[neighborID*3+1], y[neighborID*3+2]);
         if(currentDistanceSquared < contactRadiusSquared){

--- a/src/core/Peridigm.cpp
+++ b/src/core/Peridigm.cpp
@@ -1036,7 +1036,7 @@ void PeridigmNS::Peridigm::InitializeRestart() {
       }
     }else{
       if(peridigmComm->MyPID() == 0){
-        TEUCHOS_TEST_FOR_EXCEPT_MSG(true, "Error: Initial restart folder exists, but it is not suitable for a restart. \n");
+        TEUCHOS_TEST_FOR_TERMINATION(true, "Error: Initial restart folder exists, but it is not suitable for a restart. \n");
         MPI_Finalize();
         exit(0);
       }
@@ -1727,18 +1727,18 @@ void PeridigmNS::Peridigm::executeExplicit(Teuchos::RCP<Teuchos::ParameterList> 
     // Check for NaNs in force evaluation
     // We'd like to know now because a NaN will likely cause a difficult-to-unravel crash downstream.
     for(int i=0 ; i<force->MyLength() ; ++i)
-      TEUCHOS_TEST_FOR_EXCEPT_MSG(!std::isfinite((*force)[i]), "**** NaN returned by force evaluation.\n");
+      TEUCHOS_TEST_FOR_TERMINATION(!std::isfinite((*force)[i]), "**** NaN returned by force evaluation.\n");
 
     // Check for NaNs in force evaluation
     // We'd like to know now because a NaN will likely cause a difficult-to-unravel crash downstream.
     for(int i=0 ; i<externalForce->MyLength() ; ++i)
-      TEUCHOS_TEST_FOR_EXCEPT_MSG(!std::isfinite((*externalForce)[i]), "**** NaN returned by external force evaluation.\n");
+      TEUCHOS_TEST_FOR_TERMINATION(!std::isfinite((*externalForce)[i]), "**** NaN returned by external force evaluation.\n");
 
     if(analysisHasContact){
       contactManager->exportData(contactForce);
       // Check for NaNs in contact force evaluation
       for(int i=0 ; i<contactForce->MyLength() ; ++i)
-        TEUCHOS_TEST_FOR_EXCEPT_MSG(!std::isfinite((*contactForce)[i]), "**** NaN returned by contact force evaluation.\n");
+        TEUCHOS_TEST_FOR_TERMINATION(!std::isfinite((*contactForce)[i]), "**** NaN returned by contact force evaluation.\n");
       // Add contact forces to forces
       force->Update(1.0, *contactForce, 1.0);
     }
@@ -1791,28 +1791,28 @@ bool PeridigmNS::Peridigm::computePreconditioner(const Epetra_Vector& x, Epetra_
 
   // Invert the 3x3 block tangent
   PeridigmNS::Timer::self().startTimer("Invert 3x3 Block Tangent");
-  TEUCHOS_TEST_FOR_EXCEPT_MSG(tangent->NumMyRows()%3 != 0, "****Error in Peridigm::computePreconditioner(), invalid number of rows.\n");
+  TEUCHOS_TEST_FOR_TERMINATION(tangent->NumMyRows()%3 != 0, "****Error in Peridigm::computePreconditioner(), invalid number of rows.\n");
   int numEntries, err;
   double *valuesRow1, *valuesRow2, *valuesRow3;
   double matrix[9], determinant, inverse[9];
   for(int iBlock=0 ; iBlock<tangent->NumMyRows() ; iBlock+=3){
     err = tangent->ExtractMyRowView(iBlock, numEntries, valuesRow1);
-    TEUCHOS_TEST_FOR_EXCEPT_MSG(err != 0, "**** PeridigmNS::Peridigm::computePreconditioner(), tangent->ExtractMyRowView() returned nonzero error code.\n");
-    TEUCHOS_TEST_FOR_EXCEPT_MSG(numEntries != 3, "**** PeridigmNS::Peridigm::computePreconditioner(), number of row entries not equal to three (block 3x3 matrix required).\n");
+    TEUCHOS_TEST_FOR_TERMINATION(err != 0, "**** PeridigmNS::Peridigm::computePreconditioner(), tangent->ExtractMyRowView() returned nonzero error code.\n");
+    TEUCHOS_TEST_FOR_TERMINATION(numEntries != 3, "**** PeridigmNS::Peridigm::computePreconditioner(), number of row entries not equal to three (block 3x3 matrix required).\n");
     for(int i=0 ; i<3 ; ++i)
       matrix[i] = valuesRow1[i];
     err = tangent->ExtractMyRowView(iBlock+1, numEntries, valuesRow2);
-    TEUCHOS_TEST_FOR_EXCEPT_MSG(err != 0, "**** PeridigmNS::Peridigm::computePreconditioner(), tangent->ExtractMyRowView() returned nonzero error code.\n");
-    TEUCHOS_TEST_FOR_EXCEPT_MSG(numEntries != 3, "**** PeridigmNS::Peridigm::computePreconditioner(), number of row entries not equal to three (block 3x3 matrix required).\n");
+    TEUCHOS_TEST_FOR_TERMINATION(err != 0, "**** PeridigmNS::Peridigm::computePreconditioner(), tangent->ExtractMyRowView() returned nonzero error code.\n");
+    TEUCHOS_TEST_FOR_TERMINATION(numEntries != 3, "**** PeridigmNS::Peridigm::computePreconditioner(), number of row entries not equal to three (block 3x3 matrix required).\n");
     for(int i=0 ; i<3 ; ++i)
       matrix[3+i] = valuesRow2[i];
     err = tangent->ExtractMyRowView(iBlock+2, numEntries, valuesRow3);
-    TEUCHOS_TEST_FOR_EXCEPT_MSG(err != 0, "**** PeridigmNS::Peridigm::computePreconditioner(), tangent->ExtractMyRowView() returned nonzero error code.\n");
-    TEUCHOS_TEST_FOR_EXCEPT_MSG(numEntries != 3, "**** PeridigmNS::Peridigm::computePreconditioner(), number of row entries not equal to three (block 3x3 matrix required).\n");
+    TEUCHOS_TEST_FOR_TERMINATION(err != 0, "**** PeridigmNS::Peridigm::computePreconditioner(), tangent->ExtractMyRowView() returned nonzero error code.\n");
+    TEUCHOS_TEST_FOR_TERMINATION(numEntries != 3, "**** PeridigmNS::Peridigm::computePreconditioner(), number of row entries not equal to three (block 3x3 matrix required).\n");
     for(int i=0 ; i<3 ; ++i)
       matrix[6+i] = valuesRow3[i];
     err = CORRESPONDENCE::Invert3by3Matrix(matrix, determinant, inverse);
-    TEUCHOS_TEST_FOR_EXCEPT_MSG(err != 0, "**** PeridigmNS::Peridigm::computePreconditioner(), Invert3by3Matrix() returned nonzero error code.\n");
+    TEUCHOS_TEST_FOR_TERMINATION(err != 0, "**** PeridigmNS::Peridigm::computePreconditioner(), Invert3by3Matrix() returned nonzero error code.\n");
     for(int i=0 ; i<3 ; ++i){
       valuesRow1[i] = inverse[i];
       valuesRow2[i] = inverse[3+i];
@@ -1968,10 +1968,10 @@ bool PeridigmNS::Peridigm::evaluateNOX(NOX::Epetra::Interface::Required::FillTyp
     // copy the internal force to the residual vector
     // note that due to restrictions on CrsMatrix, these vectors have different (but equivalent) maps
     if(not analysisHasMultiphysics){
-      TEUCHOS_TEST_FOR_EXCEPT_MSG(residual->MyLength() != force->MyLength(), "**** PeridigmNS::Peridigm::evaluateNOX() incompatible vector lengths!\n");
+      TEUCHOS_TEST_FOR_TERMINATION(residual->MyLength() != force->MyLength(), "**** PeridigmNS::Peridigm::evaluateNOX() incompatible vector lengths!\n");
     }
     else{
-      TEUCHOS_TEST_FOR_EXCEPT_MSG(residual->MyLength() != unknownsForce->MyLength(), "**** PeridigmNS::Peridigm::evaluateNOX() incompatible vector lengths! (residual with unknownsForce)\n");
+      TEUCHOS_TEST_FOR_TERMINATION(residual->MyLength() != unknownsForce->MyLength(), "**** PeridigmNS::Peridigm::evaluateNOX() incompatible vector lengths! (residual with unknownsForce)\n");
     }
 
     if(analysisHasMultiphysics){
@@ -2002,7 +2002,7 @@ bool PeridigmNS::Peridigm::evaluateNOX(NOX::Epetra::Interface::Required::FillTyp
     PeridigmNS::Timer::self().startTimer("Evaluate Jacobian");
     modelEvaluator->evalJacobian(workset);
     int err = tangent->GlobalAssemble();
-    TEUCHOS_TEST_FOR_EXCEPT_MSG(err != 0, "**** PeridigmNS::Peridigm::evaluateNOX(), GlobalAssemble() returned nonzero error code.\n");
+    TEUCHOS_TEST_FOR_TERMINATION(err != 0, "**** PeridigmNS::Peridigm::evaluateNOX(), GlobalAssemble() returned nonzero error code.\n");
     PeridigmNS::Timer::self().stopTimer("Evaluate Jacobian");
     boundaryAndInitialConditionManager->applyKinematicBC_InsertZerosAndSetDiagonal(tangent);
   }
@@ -2021,10 +2021,10 @@ void PeridigmNS::Peridigm::computeInternalForce()
 
   // Run some checks to make sure things haven't gone haywire
   for(int i=0 ; i<u->MyLength() ; ++i){
-    TEUCHOS_TEST_FOR_EXCEPT_MSG(!std::isfinite((*x)[i]), "**** NaN detetected in vector x in Peridigm::computeInternalForce().\n");
-    TEUCHOS_TEST_FOR_EXCEPT_MSG(!std::isfinite((*u)[i]), "**** NaN detetected in vector u in Peridigm::computeInternalForce().\n");
-    TEUCHOS_TEST_FOR_EXCEPT_MSG(!std::isfinite((*y)[i]), "**** NaN detetected in vector y in Peridigm::computeInternalForce().\n");
-    TEUCHOS_TEST_FOR_EXCEPT_MSG(!std::isfinite((*v)[i]), "**** NaN detetected in vector v in Peridigm::computeInternalForce().\n");
+    TEUCHOS_TEST_FOR_TERMINATION(!std::isfinite((*x)[i]), "**** NaN detetected in vector x in Peridigm::computeInternalForce().\n");
+    TEUCHOS_TEST_FOR_TERMINATION(!std::isfinite((*u)[i]), "**** NaN detetected in vector u in Peridigm::computeInternalForce().\n");
+    TEUCHOS_TEST_FOR_TERMINATION(!std::isfinite((*y)[i]), "**** NaN detetected in vector y in Peridigm::computeInternalForce().\n");
+    TEUCHOS_TEST_FOR_TERMINATION(!std::isfinite((*v)[i]), "**** NaN detetected in vector v in Peridigm::computeInternalForce().\n");
   }
 
   // Copy data from mothership vectors to overlap vectors in data manager
@@ -2051,7 +2051,7 @@ void PeridigmNS::Peridigm::computeInternalForce()
 
   // Run some checks to make sure things haven't gone haywire
   for(int i=0 ; i<force->MyLength() ; ++i){
-    TEUCHOS_TEST_FOR_EXCEPT_MSG(!std::isfinite((*force)[i]), "**** NaN detetected in force vector in Peridigm::computeInternalForce().\n");
+    TEUCHOS_TEST_FOR_TERMINATION(!std::isfinite((*force)[i]), "**** NaN detetected in force vector in Peridigm::computeInternalForce().\n");
   }
 
   // convert force density to force
@@ -2082,26 +2082,26 @@ void PeridigmNS::Peridigm::jacobianDiagnostics(Teuchos::RCP<NOX::Epetra::Group> 
   // Construct transpose
   Teuchos::RCP<Epetra_Operator> jacobianOperator = noxGroup->getLinearSystem()->getJacobianOperator();
   Epetra_CrsMatrix* jacobian = dynamic_cast<Epetra_CrsMatrix*>(jacobianOperator.get());
-  TEUCHOS_TEST_FOR_EXCEPT_MSG(jacobian == NULL, "\n****Error: jacobianDiagnostics() failed to convert jacobian to Epetra_CrsMatrix.\n");
+  TEUCHOS_TEST_FOR_TERMINATION(jacobian == NULL, "\n****Error: jacobianDiagnostics() failed to convert jacobian to Epetra_CrsMatrix.\n");
   Epetra_CrsMatrix jacobianTranspose(*jacobian);
   Epetra_CrsMatrix* jacobianTransposePtr = &jacobianTranspose;
   Epetra_RowMatrixTransposer jacobianTransposer(jacobian);
   bool makeDataContiguous = false;
   int returnCode = jacobianTransposer.CreateTranspose(makeDataContiguous, jacobianTransposePtr);
-  TEUCHOS_TEST_FOR_EXCEPT_MSG(returnCode != 0, "\n****Error: jacobianDiagnostics() failed to transpose jacobian.\n");
+  TEUCHOS_TEST_FOR_TERMINATION(returnCode != 0, "\n****Error: jacobianDiagnostics() failed to transpose jacobian.\n");
 
   // Replace entries in transpose with 0.5*(J - J^T)
   int numRows = jacobian->NumMyRows();
-  TEUCHOS_TEST_FOR_EXCEPT_MSG(numRows != jacobianTranspose.NumMyRows(), "\n****Error: jacobianDiagnostics() incompatible matrices.\n");
+  TEUCHOS_TEST_FOR_TERMINATION(numRows != jacobianTranspose.NumMyRows(), "\n****Error: jacobianDiagnostics() incompatible matrices.\n");
   int numEntries, numEntriesTranspose;
   double *values, *valuesTranspose;
   int *indices, *indicesTranspose;
   for(int i=0; i<numRows; i++){
     jacobian->ExtractMyRowView(i, numEntries, values, indices);
     jacobianTranspose.ExtractMyRowView(i, numEntriesTranspose, valuesTranspose, indicesTranspose);
-    TEUCHOS_TEST_FOR_EXCEPT_MSG(numEntries != numEntriesTranspose, "\n****Error: jacobianDiagnostics() incompatible matrices.\n");
+    TEUCHOS_TEST_FOR_TERMINATION(numEntries != numEntriesTranspose, "\n****Error: jacobianDiagnostics() incompatible matrices.\n");
     for (int j=0; j<numEntries; j++){
-      TEUCHOS_TEST_FOR_EXCEPT_MSG(indices[j] != indicesTranspose[j], "\n****Error: jacobianDiagnostics() incompatible matrices.\n");
+      TEUCHOS_TEST_FOR_TERMINATION(indices[j] != indicesTranspose[j], "\n****Error: jacobianDiagnostics() incompatible matrices.\n");
       valuesTranspose[j] = fabs(0.5*(values[j]-valuesTranspose[j]));
     }
   }
@@ -2554,11 +2554,10 @@ void PeridigmNS::Peridigm::executeNOXQuasiStatic(Teuchos::RCP<Teuchos::Parameter
 
       solverIteration += 1;
     }
-    TEUCHOS_TEST_FOR_EXCEPT_MSG(noxSolverStatus != NOX::StatusTest::Converged, "\n****Error:  NOX solver failed to solve system.\n");
+    TEUCHOS_TEST_FOR_TERMINATION(noxSolverStatus != NOX::StatusTest::Converged, "\n****Error:  NOX solver failed to solve system.\n");
 
     // Get the Epetra_Vector with the final solution from the solver
-    const Epetra_Vector& finalSolution = 
-      dynamic_cast<const NOX::Epetra::Vector&>(solver->getSolutionGroup().getX()).getEpetraVector();
+    const Epetra_Vector& finalSolution = dynamic_cast<const NOX::Epetra::Vector&>(solver->getSolutionGroup().getX()).getEpetraVector();
  
     // Print load step timing information
     double CPUTime = loadStepCPUTime.ElapsedTime();
@@ -2955,7 +2954,7 @@ void PeridigmNS::Peridigm::executeQuasiStatic(Teuchos::RCP<Teuchos::ParameterLis
           modelEvaluator->evalJacobian(workset);
           int err = tangent->GlobalAssemble();
 
-          TEUCHOS_TEST_FOR_EXCEPT_MSG(err != 0, "**** PeridigmNS::Peridigm::executeQuasiStatic(), GlobalAssemble() returned nonzero error code.\n");
+          TEUCHOS_TEST_FOR_TERMINATION(err != 0, "**** PeridigmNS::Peridigm::executeQuasiStatic(), GlobalAssemble() returned nonzero error code.\n");
           PeridigmNS::Timer::self().stopTimer("Evaluate Jacobian");
           boundaryAndInitialConditionManager->applyKinematicBC_InsertZeros(residual);
           boundaryAndInitialConditionManager->applyKinematicBC_InsertZerosAndSetDiagonal(tangent);
@@ -3356,7 +3355,7 @@ void PeridigmNS::Peridigm::executeImplicitDiffusion(Teuchos::RCP<Teuchos::Parame
       PeridigmNS::Timer::self().startTimer("Evaluate Jacobian");
       modelEvaluator->evalJacobian(workset);
       int err = tangent->GlobalAssemble();
-      TEUCHOS_TEST_FOR_EXCEPT_MSG(err != 0, "**** PeridigmNS::Peridigm::executeImplicitDiffusion(), GlobalAssemble() returned nonzero error code.\n");
+      TEUCHOS_TEST_FOR_TERMINATION(err != 0, "**** PeridigmNS::Peridigm::executeImplicitDiffusion(), GlobalAssemble() returned nonzero error code.\n");
       PeridigmNS::Timer::self().stopTimer("Evaluate Jacobian");
       boundaryAndInitialConditionManager->applyKinematicBC_InsertZeros(residual);
       boundaryAndInitialConditionManager->applyKinematicBC_InsertZerosAndSetDiagonal(tangent);
@@ -3492,7 +3491,7 @@ Belos::ReturnType PeridigmNS::Peridigm::quasiStaticsSolveSystem(Teuchos::RCP<Epe
   lhs->PutScalar(0.0);
   linearProblem.setOperator(tangent);
   bool isSet = linearProblem.setProblem(lhs, residual);
-  TEUCHOS_TEST_FOR_EXCEPT_MSG(!isSet, "**** Belos::LinearProblem::setProblem() returned nonzero error code.\n");
+  TEUCHOS_TEST_FOR_TERMINATION(!isSet, "**** Belos::LinearProblem::setProblem() returned nonzero error code.\n");
   try{
     isConverged = belosSolver->solve();
   }
@@ -3557,7 +3556,7 @@ double PeridigmNS::Peridigm::quasiStaticsLineSearch(Teuchos::RCP<Epetra_Vector> 
 
   // compute the current residual
   double unperturbedResidualNorm = computeQuasiStaticResidual(residual);
-  TEUCHOS_TEST_FOR_EXCEPT_MSG(!std::isfinite(unperturbedResidualNorm), "**** NaN detected in residual calculation in quasiStaticsLineSearch().\n");
+  TEUCHOS_TEST_FOR_TERMINATION(!std::isfinite(unperturbedResidualNorm), "**** NaN detected in residual calculation in quasiStaticsLineSearch().\n");
   if(unperturbedResidualNorm == 0.0)
     return 0.0;
 
@@ -4041,7 +4040,7 @@ void PeridigmNS::Peridigm::executeImplicit(Teuchos::RCP<Teuchos::ParameterList> 
 
       bool isSet = linearProblem.setProblem(displacementIncrement, residual);
 
-      TEUCHOS_TEST_FOR_EXCEPT_MSG(!isSet, "**** Peridigm::executeImplicit(), failed to set linear problem.\n");
+      TEUCHOS_TEST_FOR_TERMINATION(!isSet, "**** Peridigm::executeImplicit(), failed to set linear problem.\n");
       PeridigmNS::Timer::self().startTimer("Solve Linear System");
       Belos::ReturnType isConverged = belosSolver->solve();
       if(isConverged != Belos::Converged && peridigmComm->MyPID() == 0)
@@ -4262,12 +4261,12 @@ void PeridigmNS::Peridigm::allocateJacobian() {
 
     // Allocate space in the global matrix
     int err = tangent->InsertGlobalValues(rowEntry->first, numRowNonzeros, (const double*)&zeros[0], (const int*)&indices[0]);
-    TEUCHOS_TEST_FOR_EXCEPT_MSG(err < 0, "**** PeridigmNS::Peridigm::allocateJacobian(), InsertGlobalValues() returned negative error code.\n");
+    TEUCHOS_TEST_FOR_TERMINATION(err < 0, "**** PeridigmNS::Peridigm::allocateJacobian(), InsertGlobalValues() returned negative error code.\n");
 
     rowEntry->second.clear();
   }
   int err = tangent->GlobalAssemble();
-  TEUCHOS_TEST_FOR_EXCEPT_MSG(err != 0, "**** PeridigmNS::Peridigm::allocateJacobian(), GlobalAssemble() returned nonzero error code.\n");
+  TEUCHOS_TEST_FOR_TERMINATION(err != 0, "**** PeridigmNS::Peridigm::allocateJacobian(), GlobalAssemble() returned nonzero error code.\n");
 
   // create the serial Jacobian
   overlapJacobian = Teuchos::rcp(new PeridigmNS::SerialMatrix(tangent));
@@ -4321,10 +4320,10 @@ void PeridigmNS::Peridigm::allocateBlockDiagonalJacobian() {
     rowEntries[1] = 3*(static_cast<int>(globalId)/3) + 1;
     rowEntries[2] = 3*(static_cast<int>(globalId)/3) + 2;
     err = blockDiagonalTangent->InsertGlobalValues(globalId, numEntriesPerRow, zeros, (const int*)rowEntries);
-    TEUCHOS_TEST_FOR_EXCEPT_MSG(err < 0, "**** PeridigmNS::Peridigm::allocateblockDiagonalJacobian(), InsertGlobalValues() returned negative error code.\n");
+    TEUCHOS_TEST_FOR_TERMINATION(err < 0, "**** PeridigmNS::Peridigm::allocateblockDiagonalJacobian(), InsertGlobalValues() returned negative error code.\n");
   }
   err = blockDiagonalTangent->GlobalAssemble();
-  TEUCHOS_TEST_FOR_EXCEPT_MSG(err != 0, "**** PeridigmNS::Peridigm::allocateBlockDiagonalJacobian(), GlobalAssemble() returned nonzero error code.\n");
+  TEUCHOS_TEST_FOR_TERMINATION(err != 0, "**** PeridigmNS::Peridigm::allocateBlockDiagonalJacobian(), GlobalAssemble() returned nonzero error code.\n");
 
   // create the serial Jacobian
   overlapJacobian = Teuchos::rcp(new PeridigmNS::SerialMatrix(blockDiagonalTangent));
@@ -4387,7 +4386,7 @@ double PeridigmNS::Peridigm::computeQuasiStaticResidual(Teuchos::RCP<Epetra_Vect
     for(int i_node = 0; i_node < force->Map().NumMyElements(); ++i_node) {
       for (int dof = 0; dof < numDisplacementDofs; ++dof) {
         double value = force_ptr[i_node*numDisplacementDofs + dof];
-        TEUCHOS_TEST_FOR_EXCEPT_MSG(!std::isfinite(value), "**** NaN returned by force evaluation.\n");
+        TEUCHOS_TEST_FOR_TERMINATION(!std::isfinite(value), "**** NaN returned by force evaluation.\n");
         residual_ptr[i_node*numDofs + displacementDofOffset + dof] = value;
       }
     }
@@ -4405,7 +4404,7 @@ double PeridigmNS::Peridigm::computeQuasiStaticResidual(Teuchos::RCP<Epetra_Vect
     fluxDivergence->ExtractView(&flux_divergence_ptr);
     for(int i_node = 0; i_node < fluxDivergence->Map().NumMyElements(); ++i_node) {
       double value = flux_divergence_ptr[i_node];
-      TEUCHOS_TEST_FOR_EXCEPT_MSG(!std::isfinite(value), "**** NaN returned by flux divergence evaluation.\n");
+      TEUCHOS_TEST_FOR_TERMINATION(!std::isfinite(value), "**** NaN returned by flux divergence evaluation.\n");
       residual_ptr[i_node*numDofs + temperatureDofOffset] = value;
     }
   }
@@ -4422,7 +4421,7 @@ double PeridigmNS::Peridigm::computeQuasiStaticResidual(Teuchos::RCP<Epetra_Vect
     concentrationFluxDivergence->ExtractView(&concentration_flux_divergence_ptr);
     for(int i_node = 0; i_node < concentrationFluxDivergence->Map().NumMyElements(); ++i_node) {
       double value = concentration_flux_divergence_ptr[i_node];
-      TEUCHOS_TEST_FOR_EXCEPT_MSG(!std::isfinite(value), "**** NaN returned by concentration flux divergence evaluation.\n");
+      TEUCHOS_TEST_FOR_TERMINATION(!std::isfinite(value), "**** NaN returned by concentration flux divergence evaluation.\n");
       residual_ptr[i_node*numDofs + concentrationDofOffset] = value;
     }
   }
@@ -4439,7 +4438,7 @@ double PeridigmNS::Peridigm::computeQuasiStaticResidual(Teuchos::RCP<Epetra_Vect
     fluidFlow->ExtractView(&fluid_flow_ptr);
     for(int i_node = 0; i_node < fluidFlow->Map().NumMyElements(); ++i_node) {
       double value = fluid_flow_ptr[i_node];
-      TEUCHOS_TEST_FOR_EXCEPT_MSG(!std::isfinite(value), "**** NaN returned by fluid flow evaluation.\n");
+      TEUCHOS_TEST_FOR_TERMINATION(!std::isfinite(value), "**** NaN returned by fluid flow evaluation.\n");
       residual_ptr[i_node*numDofs + pressureDofOffset] = value;
     }
   }
@@ -4485,7 +4484,7 @@ void PeridigmNS::Peridigm::computeImplicitJacobian(double beta, double dt) {
   PeridigmNS::Timer::self().startTimer("Evaluate Jacobian");
   modelEvaluator->evalJacobian(workset);
   int err = tangent->GlobalAssemble();
-  TEUCHOS_TEST_FOR_EXCEPT_MSG(err != 0, "**** PeridigmNS::Peridigm::computeImplicitJacobian(), GlobalAssemble() returned nonzero error code.\n");
+  TEUCHOS_TEST_FOR_TERMINATION(err != 0, "**** PeridigmNS::Peridigm::computeImplicitJacobian(), GlobalAssemble() returned nonzero error code.\n");
   PeridigmNS::Timer::self().stopTimer("Evaluate Jacobian");
 
   // tangent = M - beta*dt*dt*K
@@ -4572,7 +4571,7 @@ Teuchos::RCP< map< string, vector<int> > > PeridigmNS::Peridigm::getExodusNodeSe
     vector<int>& exodusNodeSet = (*exodusNodeSets)[nodeSetName];
     for(unsigned int i=0 ; i<nodeSet.size() ; ++i){
       int localId = oneDimensionalMap->LID(nodeSet[i]);
-      TEUCHOS_TEST_FOR_EXCEPT_MSG(localId == -1, "**** Error, Peridigm::getExodusNodeSets() encountered off-processor node in node set.\n");
+      TEUCHOS_TEST_FOR_TERMINATION(localId == -1, "**** Error, Peridigm::getExodusNodeSets() encountered off-processor node in node set.\n");
       exodusNodeSet.push_back(localId + 1);
     }
   }

--- a/src/core/Peridigm_Block.cpp
+++ b/src/core/Peridigm_Block.cpp
@@ -165,11 +165,11 @@ void PeridigmNS::DataManagerSynchronizer::checkFieldValidity(Teuchos::RCP< std::
     FieldSpec fieldSpec = PeridigmNS::FieldManager::self().getFieldSpec(fieldId);
 
     PeridigmField::Relation relation = fieldSpec.getRelation();
-    TEUCHOS_TEST_FOR_EXCEPT_MSG((relation != PeridigmField::NODE && relation != PeridigmField::ELEMENT),
+    TEUCHOS_TEST_FOR_TERMINATION((relation != PeridigmField::NODE && relation != PeridigmField::ELEMENT),
                                 "**** Error in DataManagerSynchronizer::checkFieldValidity():  Parallel synchronization available only for node and elemet variables.\n");
 
     PeridigmField::Length length = fieldSpec.getLength();
-    TEUCHOS_TEST_FOR_EXCEPT_MSG((length != PeridigmField::SCALAR && length != PeridigmField::VECTOR),
+    TEUCHOS_TEST_FOR_TERMINATION((length != PeridigmField::SCALAR && length != PeridigmField::VECTOR),
                                 "**** Error in DataManagerSynchronizer::checkFieldValidity():  Parallel synchronization available only for scalar and vector variables.\n");
 
     PeridigmField::Temporal temporal = fieldSpec.getTemporal();
@@ -184,7 +184,7 @@ void PeridigmNS::DataManagerSynchronizer::checkFieldValidity(Teuchos::RCP< std::
         std::stringstream ss;
         ss << "**** Error in DataManagerSynchronizer::checkFieldValidity():  Field ";
         ss << fieldSpec.getLabel() << " not present in block " << blockIt->getName() << ".\n";
-        TEUCHOS_TEST_FOR_EXCEPT_MSG(!hasField, ss.str());
+        TEUCHOS_TEST_FOR_TERMINATION(!hasField, ss.str());
       }
     }
   }
@@ -242,7 +242,7 @@ void PeridigmNS::DataManagerSynchronizer::synchronize(Teuchos::RCP< std::vector<
       }
     }
     else {
-      TEUCHOS_TEST_FOR_EXCEPT_MSG((length != PeridigmField::SCALAR && length != PeridigmField::VECTOR),
+      TEUCHOS_TEST_FOR_TERMINATION((length != PeridigmField::SCALAR && length != PeridigmField::VECTOR),
                                   "**** Error in DataManagerSynchronizer::synchronize():  Parallel synchronization available only for scalar and vector variables.\n");
     }
   }

--- a/src/core/Peridigm_BlockBase.hpp
+++ b/src/core/Peridigm_BlockBase.hpp
@@ -128,25 +128,19 @@ namespace PeridigmNS {
 
     //! Get the number of points in the block (does not include ghosts)
     int numPoints() {
-      TEUCHOS_TEST_FOR_EXCEPT_MSG(
-        ownedScalarPointMap.is_null(),
-        "\n**** Error in BlockBase::numPoints():  Map not set, pointer is null.\n");
+      TEUCHOS_TEST_FOR_EXCEPT_MSG(ownedScalarPointMap.is_null(), "\n**** Error in BlockBase::numPoints():  Map not set, pointer is null.\n");
       return ownedScalarPointMap->NumMyElements();
     }
 
     //! Method for accessing data from the DataManager.
     Teuchos::RCP<Epetra_Vector> getData(int fieldId, PeridigmField::Step step){
-      TEUCHOS_TEST_FOR_EXCEPT_MSG(
-        dataManager.is_null(),
-        "\n**** DataManager must be initialized via BlockBase::initializeDataManager() prior to calling BlockBase::getData()\n");
+      TEUCHOS_TEST_FOR_EXCEPT_MSG(dataManager.is_null(), "\n**** DataManager must be initialized via BlockBase::initializeDataManager() prior to calling BlockBase::getData()\n");
       return dataManager->getData(fieldId, step);
     }
 
     //! Method for querying the DataManager for the presence of a field spec.
     bool hasData(int fieldId, PeridigmField::Step step) const {
-      TEUCHOS_TEST_FOR_EXCEPT_MSG(
-        dataManager.is_null(),
-        "\n**** DataManager must be initialized via BlockBase::initializeDataManager() prior to calling BlockBase::hasData()\n");
+      TEUCHOS_TEST_FOR_EXCEPT_MSG(dataManager.is_null(), "\n**** DataManager must be initialized via BlockBase::initializeDataManager() prior to calling BlockBase::hasData()\n");
       return dataManager->hasData(fieldId, step);
     }
 

--- a/src/core/Peridigm_BoundaryAndInitialConditionManager.cpp
+++ b/src/core/Peridigm_BoundaryAndInitialConditionManager.cpp
@@ -326,7 +326,7 @@ void PeridigmNS::BoundaryAndInitialConditionManager::applyKinematicBC_ComputeRea
 {
   PeridigmNS::Timer::self().startTimer("Apply Boundary Conditions");
 
-  TEUCHOS_TEST_FOR_EXCEPT_MSG(force->Map().ElementSize() != reaction->Map().ElementSize(), "**** In applyKinematicBC_ComputeReactions(), incompatible vector maps.");
+  TEUCHOS_TEST_FOR_TERMINATION(force->Map().ElementSize() != reaction->Map().ElementSize(), "**** In applyKinematicBC_ComputeReactions(), incompatible vector maps.");
 
   reaction->PutScalar(0.0);
 
@@ -374,7 +374,7 @@ void PeridigmNS::BoundaryAndInitialConditionManager::applyKinematicBC_InsertZero
   PeridigmNS::Timer::self().startTimer("Apply Boundary Conditions");
 
   const Epetra_BlockMap& oneDimensionalMap = vec->Map();
-  TEUCHOS_TEST_FOR_EXCEPT_MSG(oneDimensionalMap.ElementSize() != 1, "**** applyKinematicBC_InsertZeros() must be called with map having element size = 1.\n");
+  TEUCHOS_TEST_FOR_TERMINATION(oneDimensionalMap.ElementSize() != 1, "**** applyKinematicBC_InsertZeros() must be called with map having element size = 1.\n");
 
   PeridigmNS::DegreesOfFreedomManager& dofManager = PeridigmNS::DegreesOfFreedomManager::self();
   int numDof = dofManager.totalNumberOfDegreesOfFreedom();
@@ -384,9 +384,9 @@ void PeridigmNS::BoundaryAndInitialConditionManager::applyKinematicBC_InsertZero
     Teuchos::RCP<BoundaryCondition> boundaryCondition = boundaryConditions[i];
 
     if ((boundaryCondition->getType() == PRESCRIBED_DISPLACEMENT && dofManager.displacementTreatedAsUnknown()) ||
-       (boundaryCondition->getType() == PRESCRIBED_FLUID_PRESSURE_U && dofManager.pressureTreatedAsUnknown()) ||
-       (boundaryCondition->getType() == PRESCRIBED_TEMPERATURE && dofManager.temperatureTreatedAsUnknown()) ||
-       (boundaryCondition->getType() == THERMAL_FLUX && dofManager.temperatureTreatedAsUnknown())) {
+        (boundaryCondition->getType() == PRESCRIBED_FLUID_PRESSURE_U && dofManager.pressureTreatedAsUnknown()) ||
+        (boundaryCondition->getType() == PRESCRIBED_TEMPERATURE && dofManager.temperatureTreatedAsUnknown()) ||
+        (boundaryCondition->getType() == THERMAL_FLUX && dofManager.temperatureTreatedAsUnknown())) {
 
       int offset = 0;
       if (boundaryCondition->getType() == PRESCRIBED_DISPLACEMENT) {

--- a/src/core/Peridigm_BoundaryCondition.cpp
+++ b/src/core/Peridigm_BoundaryCondition.cpp
@@ -168,10 +168,10 @@ void PeridigmNS::DirichletBC::apply(Teuchos::RCP< std::map< std::string, std::ve
   if(!success){
     string msg = "\n**** Error:  rtcFunction->addBody(function) returned error code in PeridigmNS::DirichletBC::apply().\n";
     msg += "**** " + rtcFunction->getErrors() + "\n";
-    TEUCHOS_TEST_FOR_EXCEPT_MSG(!success, msg);
+    TEUCHOS_TEST_FOR_TERMINATION(!success, msg);
   }
 
-  TEUCHOS_TEST_FOR_EXCEPT_MSG(nodeSets->find(nodeSetName) == nodeSets->end(),
+  TEUCHOS_TEST_FOR_TERMINATION(nodeSets->find(nodeSetName) == nodeSets->end(),
                               "**** Error in DirichletBC::apply(), node set not found: " + nodeSetName + "\n");
   vector<int> & nodeList = nodeSets->find(nodeSetName)->second;
   for(unsigned int i=0 ; i<nodeList.size() ; i++){
@@ -180,7 +180,7 @@ void PeridigmNS::DirichletBC::apply(Teuchos::RCP< std::map< std::string, std::ve
       double currentValue = 0.0;
       double previousValue = 0.0;
       evaluateParser(localNodeID,currentValue,previousValue,timeCurrent);
-      TEUCHOS_TEST_FOR_EXCEPT_MSG(!std::isfinite(currentValue), "**** NaN returned by dirichlet BC evaluation.\n");
+      TEUCHOS_TEST_FOR_TERMINATION(!std::isfinite(currentValue), "**** NaN returned by dirichlet BC evaluation.\n");
       (*toVector)[localNodeID*fieldDimension + coord] = currentValue;
     }
   }
@@ -220,10 +220,10 @@ void PeridigmNS::DirichletIncrementBC::apply(Teuchos::RCP< std::map< std::string
   if(!success){
     string msg = "\n**** Error:  rtcFunction->addBody(function) returned nonzero error code in PeridigmNS::DirichletBC::apply().\n";
     msg += "**** " + rtcFunction->getErrors() + "\n";
-    TEUCHOS_TEST_FOR_EXCEPT_MSG(!success, msg);
+    TEUCHOS_TEST_FOR_TERMINATION(!success, msg);
   }
 
-  TEUCHOS_TEST_FOR_EXCEPT_MSG(nodeSets->find(nodeSetName) == nodeSets->end(),
+  TEUCHOS_TEST_FOR_TERMINATION(nodeSets->find(nodeSetName) == nodeSets->end(),
                               "**** Error in DirichletBC::apply(), node set not found: " + nodeSetName + "\n");
   vector<int> & nodeList = nodeSets->find(nodeSetName)->second;
   for(unsigned int i=0 ; i<nodeList.size() ; i++){
@@ -234,7 +234,7 @@ void PeridigmNS::DirichletIncrementBC::apply(Teuchos::RCP< std::map< std::string
       evaluateParser(localNodeID,currentValue,previousValue,timeCurrent,timePrevious_);
       const double value = coeff * (currentValue - previousValue)
         + deltaTCoeff * (currentValue - previousValue) * (1.0 / (timeCurrent - timePrevious_));
-      TEUCHOS_TEST_FOR_EXCEPT_MSG(!std::isfinite(value), "**** NaN returned by dirichlet increment BC evaluation.\n");
+      TEUCHOS_TEST_FOR_TERMINATION(!std::isfinite(value), "**** NaN returned by dirichlet increment BC evaluation.\n");
       (*toVector)[localNodeID*fieldDimension + coord] = value;
     }
   }
@@ -248,7 +248,7 @@ PeridigmNS::NeumannBC::NeumannBC(const string & name_,
 : BoundaryCondition(name_,bcParams_,toVector_,peridigm_){
 
   // create vector with global ids that match those in the node set
-  TEUCHOS_TEST_FOR_EXCEPT_MSG(nodeSets_->find(nodeSetName) == nodeSets_->end(),
+  TEUCHOS_TEST_FOR_TERMINATION(nodeSets_->find(nodeSetName) == nodeSets_->end(),
                               "**** Error in NeumannBC::NeumannBC(), node set not found: " + nodeSetName + "\n");
 
   vector<int> & nodeList = nodeSets_->find(nodeSetName)->second;
@@ -301,7 +301,7 @@ void PeridigmNS::NeumannBC::apply(Teuchos::RCP< std::map< std::string, std::vect
   // get the tensor order of the bc field:
   const int fieldDimension = to_dimension_size(tensorOrder);
 
-  TEUCHOS_TEST_FOR_EXCEPT_MSG(nodeSets->find(nodeSetName) == nodeSets->end(),
+  TEUCHOS_TEST_FOR_TERMINATION(nodeSets->find(nodeSetName) == nodeSets->end(),
                               "**** Error in NeumannBC::apply(), node set not found: " + nodeSetName + "\n");
   vector<int> & nodeList = nodeSets->find(nodeSetName)->second;
   for(unsigned int i=0 ; i<nodeList.size() ; i++){

--- a/src/core/Peridigm_ContactBlock.cpp
+++ b/src/core/Peridigm_ContactBlock.cpp
@@ -70,8 +70,7 @@ void PeridigmNS::ContactBlock::initialize(Teuchos::RCP<const Epetra_BlockMap> gl
                     globalNeighborhoodData);
 
   // Initialize the data manager
-
-  TEUCHOS_TEST_FOR_EXCEPT_MSG(contactModel.is_null(),
+  TEUCHOS_TEST_FOR_TERMINATION(contactModel.is_null(),
                               "\n**** Contact model must be set via ContactBlock::setContactModel() prior to calling ContactBlock::initialize()\n");
 
   // Collect all the required field Ids

--- a/src/core/Peridigm_ContactManager.cpp
+++ b/src/core/Peridigm_ContactManager.cpp
@@ -238,7 +238,7 @@ void PeridigmNS::ContactManager::initialize(Teuchos::RCP<const Epetra_BlockMap> 
     // Obtain the horizon for this block
     PeridigmNS::HorizonManager& horizonManager = PeridigmNS::HorizonManager::self();
     string blockName = contactBlockIt->getName();
-    TEUCHOS_TEST_FOR_EXCEPT_MSG(!horizonManager.blockHasConstantHorizon(blockName) , "\n**** Error, variable horizon not supported by contact!\n");
+    TEUCHOS_TEST_FOR_TERMINATION(!horizonManager.blockHasConstantHorizon(blockName) , "\n**** Error, variable horizon not supported by contact!\n");
     double blockHorizon = horizonManager.getBlockConstantHorizonValue(blockName);
 
     // For the initial implementation, assume that there is only one contact model

--- a/src/core/Peridigm_Field.cpp
+++ b/src/core/Peridigm_Field.cpp
@@ -125,7 +125,7 @@ int PeridigmNS::FieldManager::getFieldId(PeridigmField::Relation relation_,
       ss << "\n****           length:   " << it->length;
       ss << "\n****           temporal: " << it->temporal;
       ss << "\n****           label:    " << it->label;
-      TEUCHOS_TEST_FOR_EXCEPT_MSG(lcLabel_ == lcLabel, ss.str());
+      TEUCHOS_TEST_FOR_TERMINATION(lcLabel_ == lcLabel, ss.str());
     }
   }
 
@@ -153,7 +153,7 @@ int PeridigmNS::FieldManager::getFieldId(std::string label)
   map<string, int>::iterator it = labelToIdMap.find(label);
   if(it == labelToIdMap.end()){
     string msg = "\n**** Error:  getFieldId(), label not found:  " + label + "\n";
-    TEUCHOS_TEST_FOR_EXCEPT_MSG(it == labelToIdMap.end(), msg);
+    TEUCHOS_TEST_FOR_TERMINATION(it == labelToIdMap.end(), msg);
   }
   return it->second;
 }
@@ -161,7 +161,7 @@ int PeridigmNS::FieldManager::getFieldId(std::string label)
 PeridigmNS::FieldSpec PeridigmNS::FieldManager::getFieldSpec(int fieldId)
 {
   unsigned int id = static_cast<unsigned int>(fieldId);
-  TEUCHOS_TEST_FOR_EXCEPT_MSG(id >= fieldSpecs.size(), "\n**** Error:  getFieldSpec(), ID not found.\n");
+  TEUCHOS_TEST_FOR_TERMINATION(id >= fieldSpecs.size(), "\n**** Error:  getFieldSpec(), ID not found.\n");
   return fieldSpecs[id];
 }
 

--- a/src/core/Peridigm_HorizonManager.cpp
+++ b/src/core/Peridigm_HorizonManager.cpp
@@ -118,7 +118,7 @@ bool PeridigmNS::HorizonManager::blockHasConstantHorizon(string blockName){
     isConstant = horizonIsConstant["default"];
   else{
     string msg = "\n**** Error, no Horizon parameter found for block " + blockName + " and no default block parameter list provided.\n";
-    TEUCHOS_TEST_FOR_EXCEPT_MSG(true, msg);
+    TEUCHOS_TEST_FOR_TERMINATION(true, msg);
   }
   return isConstant;
 }
@@ -131,7 +131,7 @@ double PeridigmNS::HorizonManager::getBlockConstantHorizonValue(string blockName
     name = "default";
   else{
     string msg = "\n**** Error, no Horizon parameter found for block " + blockName + " and no default block parameter list provided.\n";
-    TEUCHOS_TEST_FOR_EXCEPT_MSG(true, msg);
+    TEUCHOS_TEST_FOR_TERMINATION(true, msg);
   }
   double x(0.0), y(0.0), z(0.0);
   double horizon = evaluateHorizon(name, x, y, z);
@@ -146,7 +146,7 @@ double PeridigmNS::HorizonManager::evaluateHorizon(string blockName, double x, d
     name = "default";
   else{
     string msg = "\n**** Error, no Horizon parameter found for block " + blockName + " and no default block parameter list provided.\n";
-    TEUCHOS_TEST_FOR_EXCEPT_MSG(true, msg);
+    TEUCHOS_TEST_FOR_TERMINATION(true, msg);
   }
   string horizonFunction = horizonStrings[name];
   double horizonValue(0.0);
@@ -170,7 +170,7 @@ double PeridigmNS::HorizonManager::evaluateHorizon(string blockName, double x, d
   if(!success){
     string msg = "\n**** Error in HorizonManager::evaluateHorizon().\n";
     msg += "**** " + rtcFunction->getErrors() + "\n";
-    TEUCHOS_TEST_FOR_EXCEPT_MSG(!success, msg);
+    TEUCHOS_TEST_FOR_TERMINATION(!success, msg);
   }
 
   return horizonValue;

--- a/src/core/Peridigm_SerialMatrix.cpp
+++ b/src/core/Peridigm_SerialMatrix.cpp
@@ -73,7 +73,7 @@ void PeridigmNS::SerialMatrix::addValue(int globalRow, int globalCol, double val
   data[0][0] = value;
 
   int err = FECrsMatrix->SumIntoGlobalValues(numRows, &globalRow, numCols, &globalCol, data);
-  TEUCHOS_TEST_FOR_EXCEPT_MSG(err != 0, "**** PeridigmNS::SerialMatrix::addValue(), SumIntoGlobalValues() returned nonzero error code.\n");
+  TEUCHOS_TEST_FOR_TERMINATION(err != 0, "**** PeridigmNS::SerialMatrix::addValue(), SumIntoGlobalValues() returned nonzero error code.\n");
 
   delete[] data[0];
   delete[] data;
@@ -86,7 +86,7 @@ void PeridigmNS::SerialMatrix::addValues(int numIndices, const int* globalIndice
   for(int i=0 ; i<numIndices ; ++i){
     localRowIndices[i] = FECrsMatrix->LRID(globalIndices[i]);
     int localColIndex = FECrsMatrix->LCID(globalIndices[i]);
-    TEUCHOS_TEST_FOR_EXCEPT_MSG(localColIndex == -1, "Error in PeridigmNS::SerialMatrix::addValues(), bad column index.");
+    TEUCHOS_TEST_FOR_TERMINATION(localColIndex == -1, "Error in PeridigmNS::SerialMatrix::addValues(), bad column index.");
     localColIndices[i] = localColIndex;
   }
 
@@ -95,13 +95,13 @@ void PeridigmNS::SerialMatrix::addValues(int numIndices, const int* globalIndice
     // If the row is locally owned, then sum into the global tangent with Epetra_CrsMatrix::SumIntoMyValues().
     if(localRowIndices[iRow] != -1){
       int err = FECrsMatrix->SumIntoMyValues(localRowIndices[iRow], numIndices, values[iRow], &localColIndices[0]);
-      TEUCHOS_TEST_FOR_EXCEPT_MSG(err != 0, "**** PeridigmNS::SerialMatrix::addValues(), SumIntoMyValues() returned nonzero error code.\n");
+      TEUCHOS_TEST_FOR_TERMINATION(err != 0, "**** PeridigmNS::SerialMatrix::addValues(), SumIntoMyValues() returned nonzero error code.\n");
     }
     // If the row is not locally owned, then sum into the global tangent with Epetra_FECrsMatrix::SumIntoGlobalValues().
     // This is expensive.
     else{
       int err = FECrsMatrix->SumIntoGlobalValues(globalIndices[iRow], numIndices, values[iRow], &globalIndices[0]);
-      TEUCHOS_TEST_FOR_EXCEPT_MSG(err != 0, "**** PeridigmNS::SerialMatrix::addValues(), SumIntoGlobalValues() returned nonzero error code.\n");
+      TEUCHOS_TEST_FOR_TERMINATION(err != 0, "**** PeridigmNS::SerialMatrix::addValues(), SumIntoGlobalValues() returned nonzero error code.\n");
     }
   }
 }
@@ -142,9 +142,9 @@ void PeridigmNS::SerialMatrix::addBlockDiagonalValues(int numIndices, const int*
     int e3 = 3*elem + 2;
 
     // Be sure entries exist in inverseMap
-    TEUCHOS_TEST_FOR_EXCEPT_MSG(inverseMap.count(e1)<=0, "Error in PeridigmNS::SerialMatrix::addBlockDiagonalValues(), bad index.");
-    TEUCHOS_TEST_FOR_EXCEPT_MSG(inverseMap.count(e2)<=0, "Error in PeridigmNS::SerialMatrix::addBlockDiagonalValues(), bad index.");
-    TEUCHOS_TEST_FOR_EXCEPT_MSG(inverseMap.count(e3)<=0, "Error in PeridigmNS::SerialMatrix::addBlockDiagonalValues(), bad index.");
+    TEUCHOS_TEST_FOR_TERMINATION(inverseMap.count(e1)<=0, "Error in PeridigmNS::SerialMatrix::addBlockDiagonalValues(), bad index.");
+    TEUCHOS_TEST_FOR_TERMINATION(inverseMap.count(e2)<=0, "Error in PeridigmNS::SerialMatrix::addBlockDiagonalValues(), bad index.");
+    TEUCHOS_TEST_FOR_TERMINATION(inverseMap.count(e3)<=0, "Error in PeridigmNS::SerialMatrix::addBlockDiagonalValues(), bad index.");
 
     // Store only the three block diagonal nonzeros to fill
     int idx1 = inverseMap[e1];
@@ -164,13 +164,13 @@ void PeridigmNS::SerialMatrix::addBlockDiagonalValues(int numIndices, const int*
     // If the row is locally owned, then sum into the global tangent with Epetra_CrsMatrix::SumIntoMyValues().
     if(localRowIndices[iRow] != -1){
       int err = FECrsMatrix->SumIntoMyValues(localRowIndices[iRow], blockDiagonalNumIndices, &blockDiagonalValues[0], &blockDiagonalLocalColIndices[0]);
-      TEUCHOS_TEST_FOR_EXCEPT_MSG(err != 0, "**** PeridigmNS::SerialMatrix::addBlockDiagonalValues(), SumIntoMyValues() returned nonzero error code.\n");
+      TEUCHOS_TEST_FOR_TERMINATION(err != 0, "**** PeridigmNS::SerialMatrix::addBlockDiagonalValues(), SumIntoMyValues() returned nonzero error code.\n");
     }
     // If the row is not locally owned, then sum into the global tangent with Epetra_FECrsMatrix::SumIntoGlobalValues().
     // This is expensive.
     else{
       int err = FECrsMatrix->SumIntoGlobalValues(globalIndices[iRow], blockDiagonalNumIndices, const_cast<double *>(&blockDiagonalValues[0]), const_cast<int *>(&blockDiagonalGlobalIndices[0]));
-      TEUCHOS_TEST_FOR_EXCEPT_MSG(err != 0, "**** PeridigmNS::SerialMatrix::addBlockDiagonalValues(), SumIntoGlobalValues() returned nonzero error code.\n");
+      TEUCHOS_TEST_FOR_TERMINATION(err != 0, "**** PeridigmNS::SerialMatrix::addBlockDiagonalValues(), SumIntoGlobalValues() returned nonzero error code.\n");
     }
   }
 }

--- a/src/core/Peridigm_State.cpp
+++ b/src/core/Peridigm_State.cpp
@@ -68,7 +68,7 @@ void PeridigmNS::State::allocatePointData(PeridigmField::Length length,
 
   int index = PeridigmField::variableDimension(length) - 1;
 
-  TEUCHOS_TEST_FOR_EXCEPT_MSG(!pointData[index].is_null(),
+  TEUCHOS_TEST_FOR_TERMINATION(!pointData[index].is_null(),
                               "\n**** Error:  PeridigmNS::State::allocateData(), point-wise data field of same length already allocated!\n");
 
   pointData[index] = Teuchos::rcp(new Epetra_MultiVector(*map, fieldIds.size()));
@@ -89,7 +89,7 @@ void PeridigmNS::State::allocateBondData(vector<int> fieldIds,
     fieldIdToDataVector.resize(numFieldIds);
   }
 
-  TEUCHOS_TEST_FOR_EXCEPT_MSG(!bondData.is_null(),
+  TEUCHOS_TEST_FOR_TERMINATION(!bondData.is_null(),
                               "\n**** Error:  PeridigmNS::State::allocateData(), bond data field already allocated!\n");
 
   bondData = Teuchos::rcp(new Epetra_MultiVector(*map, fieldIds.size()));

--- a/src/io/Peridigm_OutputManager_ExodusII.cpp
+++ b/src/io/Peridigm_OutputManager_ExodusII.cpp
@@ -407,7 +407,7 @@ void PeridigmNS::OutputManager_ExodusII::write(Teuchos::RCP< std::vector<Peridig
               if(retval!= 0) reportExodusError(retval, "write", "ex_put_elem_var");
             }
             else if(spec.getLength() == PeridigmField::SYMMETRIC_TENSOR) {
-              TEUCHOS_TEST_FOR_EXCEPT_MSG(spec.getLength() == PeridigmField::SYMMETRIC_TENSOR,
+              TEUCHOS_TEST_FOR_TERMINATION(spec.getLength() == PeridigmField::SYMMETRIC_TENSOR,
                                           "\nPeridigmNS::OutputManager_ExodusII::initializeExodusDatabase(), output for SYMMETRIC_TENSOR currently not supported!\n");
             }
             else if(spec.getLength() == PeridigmField::FULL_TENSOR) {
@@ -681,7 +681,7 @@ void PeridigmNS::OutputManager_ExodusII::initializeExodusDatabase(Teuchos::RCP< 
   for(std::vector<PeridigmNS::Block>::iterator blockIt = blocks->begin(); blockIt != blocks->end() ; blockIt++) {
     Teuchos::RCP<const Epetra_BlockMap> map = blockIt->getOwnedScalarPointMap();
     for(int i=0; i<map->NumMyElements() ; ++i){
-      TEUCHOS_TEST_FOR_EXCEPT_MSG(elem_map_index >= num_nodes, "\nPeridigmNS::OutputManager_ExodusII::initializeExodusDatabase(), Error processing element map!\n");
+      TEUCHOS_TEST_FOR_TERMINATION(elem_map_index >= num_nodes, "\nPeridigmNS::OutputManager_ExodusII::initializeExodusDatabase(), Error processing element map!\n");
       elem_map[elem_map_index++] = map->GID(i)+1;
     }
   }
@@ -740,7 +740,7 @@ void PeridigmNS::OutputManager_ExodusII::initializeExodusDatabase(Teuchos::RCP< 
       }
     }
     else if(spec.getLength() == PeridigmField::SYMMETRIC_TENSOR) {
-      TEUCHOS_TEST_FOR_EXCEPT_MSG(spec.getLength() == PeridigmField::SYMMETRIC_TENSOR,
+      TEUCHOS_TEST_FOR_TERMINATION(spec.getLength() == PeridigmField::SYMMETRIC_TENSOR,
                                   "\nPeridigmNS::OutputManager_ExodusII::initializeExodusDatabase(), output for SYMMETRIC_TENSOR currently not supported!\n");
       TEUCHOS_TEST_FOR_EXCEPTION(spec.getRelation() != PeridigmField::ELEMENT, std::invalid_argument,
                                  "PeridigmNS::OutputManager_ExodusII, SYMMETRIC_TENSOR variables are valid only for element data.\n");

--- a/src/io/Peridigm_ProximitySearch.cpp
+++ b/src/io/Peridigm_ProximitySearch.cpp
@@ -212,7 +212,7 @@ void PeridigmNS::ProximitySearch::GlobalProximitySearch(Teuchos::RCP<Epetra_Vect
 {
   // The proximity search does not appear to function properly if any of the search radii are set to zero
   for(int i=0 ; i<searchRadii->MyLength() ; ++i){
-    TEUCHOS_TEST_FOR_EXCEPT_MSG((*searchRadii)[i] <= 0.0, "\n****Error:  PeridigmNS::ProximitySearch::GlobalProximitySearch(), search radii must be greater than or equal to zero.\n");
+    TEUCHOS_TEST_FOR_TERMINATION((*searchRadii)[i] <= 0.0, "\n****Error:  PeridigmNS::ProximitySearch::GlobalProximitySearch(), search radii must be greater than or equal to zero.\n");
   }
 
   // Copy information from the Epetra_Vector into a QUICKGRID::Data object

--- a/src/io/Peridigm_ZoltanSearchTree.cpp
+++ b/src/io/Peridigm_ZoltanSearchTree.cpp
@@ -120,7 +120,7 @@ PeridigmNS::ZoltanSearchTree::ZoltanSearchTree(int numPoints, double* coordinate
                                  &numimp, &impgid, &implid, &imppart, &impproc,
                                  &numexp, &gid, &lid, &procs, &parts);
 
-  TEUCHOS_TEST_FOR_EXCEPT_MSG(ierr != 0, "Error in ZoltanSearchTree::ZoltanSearchTree(), call to Zoltan_LB_Partition() returned a nonzero error code.");
+  TEUCHOS_TEST_FOR_TERMINATION(ierr != 0, "Error in ZoltanSearchTree::ZoltanSearchTree(), call to Zoltan_LB_Partition() returned a nonzero error code.");
 
   for (int I = 0; I < numPoints; I++)
     partToCoordIdx[parts[I]] = I;

--- a/src/io/discretization/Peridigm_ExodusDiscretization.cpp
+++ b/src/io/discretization/Peridigm_ExodusDiscretization.cpp
@@ -311,12 +311,12 @@ void PeridigmNS::ExodusDiscretization::loadData(const string& meshFileName)
   // If there is an auxiliary map provided that has a different name, throw an
   // error because I don't know what to do with it.
   if(numElemMaps > 0){
-    TEUCHOS_TEST_FOR_EXCEPT_MSG(numElemMaps > 1,
+    TEUCHOS_TEST_FOR_TERMINATION(numElemMaps > 1,
                                 "**** Error in ExodusDiscretization::loadData(), genesis file contains invalid number of auxiliary element maps (>1).\n");
     char mapName[MAX_STR_LENGTH];
     retval = ex_get_name(exodusFileId, EX_ELEM_MAP, 1, mapName);
     if (retval != 0) reportExodusError(retval, "ExodusDiscretization::loadData()", "ex_get_name");
-    TEUCHOS_TEST_FOR_EXCEPT_MSG(string(mapName) != string("original_global_id_map"),
+    TEUCHOS_TEST_FOR_TERMINATION(string(mapName) != string("original_global_id_map"),
                                 "**** Error in ExodusDiscretization::loadData(), unknown exodus EX_ELEM_MAP: " + string(mapName) + ".\n");
     vector<int> auxMap(numElem);
     retval = ex_get_num_map(exodusFileId, EX_ELEM_MAP, 1, &auxMap[0]);
@@ -327,12 +327,12 @@ void PeridigmNS::ExodusDiscretization::loadData(const string& meshFileName)
     elemIdMap = auxMap;
   }
   if(numNodeMaps > 0){
-    TEUCHOS_TEST_FOR_EXCEPT_MSG(numNodeMaps > 1,
+    TEUCHOS_TEST_FOR_TERMINATION(numNodeMaps > 1,
                                 "**** Error in ExodusDiscretization::loadData(), genesis file contains invalid number of auxiliary node maps (>1).\n");
     char mapName[MAX_STR_LENGTH];
     retval = ex_get_name(exodusFileId, EX_NODE_MAP, 1, mapName);
     if (retval != 0) reportExodusError(retval, "ExodusDiscretization::loadData()", "ex_get_name");
-    TEUCHOS_TEST_FOR_EXCEPT_MSG(string(mapName) != string("original_global_id_map"),
+    TEUCHOS_TEST_FOR_TERMINATION(string(mapName) != string("original_global_id_map"),
                                 "**** Error in ExodusDiscretization::loadData(), unknown exodus EX_NODE_MAP: " + string(mapName) + ".\n");
     vector<int> auxMap(numNodes);
     retval = ex_get_num_map(exodusFileId, EX_NODE_MAP, 1, &auxMap[0]);
@@ -388,7 +388,7 @@ void PeridigmNS::ExodusDiscretization::loadData(const string& meshFileName)
       ss << "block_" << elemBlockId;
       elemBlockName = ss.str();
     }
-    TEUCHOS_TEST_FOR_EXCEPT_MSG(elementBlocks->find(elemBlockName) != elementBlocks->end(), "**** Duplicate block found: " + elemBlockName + "\n");
+    TEUCHOS_TEST_FOR_TERMINATION(elementBlocks->find(elemBlockName) != elementBlocks->end(), "**** Duplicate block found: " + elemBlockName + "\n");
     // Create a list for storing the element ids in this block
     (*elementBlocks)[elemBlockName] = vector<int>();
     vector<int>& elementBlock = (*elementBlocks)[elemBlockName];
@@ -569,7 +569,7 @@ void PeridigmNS::ExodusDiscretization::loadData(const string& meshFileName)
         ss << "nodelist_" << nodeSetId;
         nodeSetName = ss.str();
       }
-      TEUCHOS_TEST_FOR_EXCEPT_MSG(nodeSets->find(nodeSetName) != nodeSets->end(), "**** Duplicate node set found: " + nodeSetName + "\n");
+      TEUCHOS_TEST_FOR_TERMINATION(nodeSets->find(nodeSetName) != nodeSets->end(), "**** Duplicate node set found: " + nodeSetName + "\n");
       (*nodeSets)[nodeSetName] = vector<int>();
       (*nodeSetIds)[nodeSetName] = exodusNodeSetIds[i];
     }
@@ -893,10 +893,10 @@ PeridigmNS::ExodusDiscretization::getMaxNumBondsPerElem() const
 void PeridigmNS::ExodusDiscretization::getExodusMeshNodePositions(int globalNodeID,
                                                                vector<double>& nodePositions)
 {
-  TEUCHOS_TEST_FOR_EXCEPT_MSG(!storeExodusMesh, "**** Error:  getExodusMeshNodePositions() called, but exodus information not stored.\n");
+  TEUCHOS_TEST_FOR_TERMINATION(!storeExodusMesh, "**** Error:  getExodusMeshNodePositions() called, but exodus information not stored.\n");
 
   int localId = exodusMeshElementConnectivity->Map().LID(globalNodeID);
-  TEUCHOS_TEST_FOR_EXCEPT_MSG(localId == -1, "**** Invalid local Exodus element Id in getExodusMeshNodePositions().\n");
+  TEUCHOS_TEST_FOR_TERMINATION(localId == -1, "**** Invalid local Exodus element Id in getExodusMeshNodePositions().\n");
   unsigned int numNodes = exodusMeshElementConnectivity->Map().ElementSize(localId);
   int exodusMeshElementIndex = exodusMeshElementConnectivity->Map().FirstPointInElement(localId);
   vector<int> elementConnectivity(numNodes);
@@ -919,7 +919,7 @@ void PeridigmNS::ExodusDiscretization::getExodusMeshNodePositions(int globalNode
 
 double PeridigmNS::ExodusDiscretization::computeMaxElementDimension()
 {
-  TEUCHOS_TEST_FOR_EXCEPT_MSG(!storeExodusMesh, "**** Error:  computeMaxElementDimension() called, but exodus information not stored.\n");
+  TEUCHOS_TEST_FOR_TERMINATION(!storeExodusMesh, "**** Error:  computeMaxElementDimension() called, but exodus information not stored.\n");
   double length, volume, localMaxElementDimension(0.0);
   double x, y, z;
   int globalId, numNodes, numNodesInElement;
@@ -930,7 +930,7 @@ double PeridigmNS::ExodusDiscretization::computeMaxElementDimension()
     globalId = oneDimensionalMap->GID(iElem);
     getExodusMeshNodePositions(globalId, nodeCoordinates);
     numNodes = nodeCoordinates.size()/3;
-    TEUCHOS_TEST_FOR_EXCEPT_MSG(numNodes != 8 &&
+    TEUCHOS_TEST_FOR_TERMINATION(numNodes != 8 &&
                                 numNodes != 4 &&
                                 numNodes != 1 &&
                                 numNodes != 10 &&
@@ -1008,7 +1008,7 @@ void PeridigmNS::ExodusDiscretization::removeNonintersectingNeighborsFromNeighbo
       getExodusMeshNodePositions(neighborGlobalId, exodusNodePositions);
       horizon = (*searchRadii)[elemLocalId];
    
-      TEUCHOS_TEST_FOR_EXCEPT_MSG(exodusNodePositions.size()/3 != 8,
+      TEUCHOS_TEST_FOR_TERMINATION(exodusNodePositions.size()/3 != 8,
                                   "\n**** Error:  Element-horizon intersection calculations currently enabled only for hexahedron elements.\n");
 
 #ifdef DEBUGGING_BACKWARDS_COMPATIBILITY_NEIGHBORHOOD_LIST
@@ -1074,7 +1074,7 @@ void PeridigmNS::ExodusDiscretization::removeNonintersectingNeighborsFromNeighbo
     index += 1;
     for(int i=0 ; i<numNeighbors ; ++i){
       neighborLocalId = overlapMap->LID(refinedNeighborGlobalIdList[index]);
-      TEUCHOS_TEST_FOR_EXCEPT_MSG(neighborLocalId == -1, "\n**** Error:  Invalid local ID in removeNonintersectingNeighborsFromNeighborList().\n");
+      TEUCHOS_TEST_FOR_TERMINATION(neighborLocalId == -1, "\n**** Error:  Invalid local ID in removeNonintersectingNeighborsFromNeighborList().\n");
       neighborList[index] = neighborLocalId;
       index += 1;
     }

--- a/src/io/discretization/Peridigm_GeometryUtils.cpp
+++ b/src/io/discretization/Peridigm_GeometryUtils.cpp
@@ -386,7 +386,7 @@ double PeridigmNS::tetVolume(const std::vector<double*>& nodeCoordinates)
   // The volume is then | a . (b x c) | / 6
   double volume = scalarTripleProduct(a, b, c) / 6.0;
 
-  TEUCHOS_TEST_FOR_EXCEPT_MSG(volume < 0.0, "\n**** Error:  tetVolume() computed negative volume, possible element inversion or incorrect node numbering.\n");
+  TEUCHOS_TEST_FOR_TERMINATION(volume < 0.0, "\n**** Error:  tetVolume() computed negative volume, possible element inversion or incorrect node numbering.\n");
 
   return volume;
 }
@@ -637,8 +637,8 @@ PeridigmNS::SphereIntersection PeridigmNS::tetrahedronSphereIntersection(double*
       allInside = false;
   }
 
-  TEUCHOS_TEST_FOR_EXCEPT_MSG(allInside && allOutside, "\n**** Error:  Nonsense result in tetrahedronSphereIntersection().\n");
-  TEUCHOS_TEST_FOR_EXCEPT_MSG(!allInside && !allOutside, "\n**** Error:  Nonsense result in tetrahedronSphereIntersection().\n");
+  TEUCHOS_TEST_FOR_TERMINATION(allInside && allOutside, "\n**** Error:  Nonsense result in tetrahedronSphereIntersection().\n");
+  TEUCHOS_TEST_FOR_TERMINATION(!allInside && !allOutside, "\n**** Error:  Nonsense result in tetrahedronSphereIntersection().\n");
 
   if(allOutside)
     return OUTSIDE_SPHERE;
@@ -843,8 +843,8 @@ PeridigmNS::SphereIntersection PeridigmNS::hexahedronSphereIntersection(double* 
     }
   }
 
-  TEUCHOS_TEST_FOR_EXCEPT_MSG(allInside && allOutside, "\n**** Error:  Nonsense result in hexahedronSphereIntersection().\n");
-  TEUCHOS_TEST_FOR_EXCEPT_MSG(!allInside && !allOutside, "\n**** Error:  Nonsense result in hexahedronSphereIntersection().\n");
+  TEUCHOS_TEST_FOR_TERMINATION(allInside && allOutside, "\n**** Error:  Nonsense result in hexahedronSphereIntersection().\n");
+  TEUCHOS_TEST_FOR_TERMINATION(!allInside && !allOutside, "\n**** Error:  Nonsense result in hexahedronSphereIntersection().\n");
 
   if(allOutside)
     return OUTSIDE_SPHERE;

--- a/src/io/discretization/Peridigm_TextFileDiscretization.cpp
+++ b/src/io/discretization/Peridigm_TextFileDiscretization.cpp
@@ -167,7 +167,7 @@ QUICKGRID::Data PeridigmNS::TextFileDiscretization::getDecomp(const string& text
   // Read the text file on the root processor
   if(myPID == 0){
     ifstream inFile(textFileName.c_str());
-    TEUCHOS_TEST_FOR_EXCEPT_MSG(!inFile.is_open(), "**** Error opening discretization text file.\n");
+    TEUCHOS_TEST_FOR_TERMINATION(!inFile.is_open(), "**** Error opening discretization text file.\n");
     while(inFile.good()){
       string str;
       getline(inFile, str);
@@ -182,7 +182,7 @@ QUICKGRID::Data PeridigmNS::TextFileDiscretization::getDecomp(const string& text
         // Check for obvious problems with the data
         if(data.size() != 5){
           string msg = "\n**** Error parsing text file, invalid line: " + str + "\n";
-          TEUCHOS_TEST_FOR_EXCEPT_MSG(data.size() != 5, msg);
+          TEUCHOS_TEST_FOR_TERMINATION(data.size() != 5, msg);
         }
         // Store the coordinates, block id, and volumes
         coordinates.push_back(data[0]);
@@ -196,7 +196,7 @@ QUICKGRID::Data PeridigmNS::TextFileDiscretization::getDecomp(const string& text
   }
 
   int numElements = static_cast<int>(blockIds.size());
-  TEUCHOS_TEST_FOR_EXCEPT_MSG(myPID == 0 && numElements < 1, "**** Error reading discretization text file, no data found.\n");
+  TEUCHOS_TEST_FOR_TERMINATION(myPID == 0 && numElements < 1, "**** Error reading discretization text file, no data found.\n");
 
   // Record the block ids on the root processor
   set<int> uniqueBlockIds;
@@ -273,7 +273,7 @@ QUICKGRID::Data PeridigmNS::TextFileDiscretization::getDecomp(const string& text
   for(int i=0 ; i<rebalancedBlockID.MyLength() ; ++i){
     stringstream blockName;
     blockName << "block_" << rebalancedBlockID[i];
-    TEUCHOS_TEST_FOR_EXCEPT_MSG(elementBlocks->find(blockName.str()) == elementBlocks->end(),
+    TEUCHOS_TEST_FOR_TERMINATION(elementBlocks->find(blockName.str()) == elementBlocks->end(),
                                 "\n**** Error in TextFileDiscretization::getDecomp(), invalid block id.\n");
     int globalID = rebalancedBlockID.Map().GID(i);
     (*elementBlocks)[blockName.str()].push_back(globalID);

--- a/src/materials/Peridigm_CorrespondenceMaterial.cpp
+++ b/src/materials/Peridigm_CorrespondenceMaterial.cpp
@@ -180,7 +180,7 @@ PeridigmNS::CorrespondenceMaterial::initialize(const double dt,
     "**** Error:  CorrespondenceMaterial::initialize() failed to compute shape tensor.\n";
   shapeTensorErrorMessage +=
     "****         Note that all nodes must have a minimum of three neighbors.  Is the horizon too small?\n";
-  TEUCHOS_TEST_FOR_EXCEPT_MSG(shapeTensorReturnCode != 0, shapeTensorErrorMessage);
+  TEUCHOS_TEST_FOR_TERMINATION(shapeTensorReturnCode != 0, shapeTensorErrorMessage);
 
 }
 
@@ -221,7 +221,7 @@ PeridigmNS::CorrespondenceMaterial::computeForce(const double dt,
     "**** Error:  CorrespondenceMaterial::computeForce() failed to compute shape tensor.\n";
   shapeTensorErrorMessage +=
     "****         Note that all nodes must have a minimum of three neighbors.  Is the horizon too small?\n";
-  TEUCHOS_TEST_FOR_EXCEPT_MSG(shapeTensorReturnCode != 0, shapeTensorErrorMessage);
+  TEUCHOS_TEST_FOR_TERMINATION(shapeTensorReturnCode != 0, shapeTensorErrorMessage);
 
   double *leftStretchTensorN, *leftStretchTensorNP1, *rotationTensorN, *rotationTensorNP1, *unrotatedRateOfDeformation;
   dataManager.getData(m_leftStretchTensorFieldId, PeridigmField::STEP_N)->ExtractView(&leftStretchTensorN);
@@ -250,7 +250,7 @@ PeridigmNS::CorrespondenceMaterial::computeForce(const double dt,
     "**** Error:  CorrespondenceMaterial::computeForce() failed to compute rotation tensor.\n";
   rotationTensorErrorMessage +=
     "****         Note that all nodes must have a minimum of three neighbors.  Is the horizon too small?\n";
-  TEUCHOS_TEST_FOR_EXCEPT_MSG(rotationTensorReturnCode != 0, rotationTensorErrorMessage);
+  TEUCHOS_TEST_FOR_TERMINATION(rotationTensorReturnCode != 0, rotationTensorErrorMessage);
 
   // Evaluate the Cauchy stress using the routine implemented in the derived class (specific correspondence material model)
   // The general idea is to compute the stress based on:
@@ -314,7 +314,7 @@ PeridigmNS::CorrespondenceMaterial::computeForce(const double dt,
     // Invert the deformation gradient and store the determinant
     int matrixInversionReturnCode =
       CORRESPONDENCE::Invert3by3Matrix(defGrad, jacobianDeterminant, defGradInv);
-    TEUCHOS_TEST_FOR_EXCEPT_MSG(matrixInversionReturnCode != 0, matrixInversionErrorMessage);
+    TEUCHOS_TEST_FOR_TERMINATION(matrixInversionReturnCode != 0, matrixInversionErrorMessage);
     
     //P = J * \sigma * F^(-T)
     CORRESPONDENCE::MatrixMultiply(false, true, jacobianDeterminant, stress, defGradInv, piolaStress);

--- a/src/materials/Peridigm_DiffusionMaterial.cpp
+++ b/src/materials/Peridigm_DiffusionMaterial.cpp
@@ -191,7 +191,7 @@ PeridigmNS::DiffusionMaterial::computeFluxDivergence(const double dt,
       kernel = 6.0/(pi*m_horizon*m_horizon*m_horizon*m_horizon*initialDistance);
       temperatureDifference = temperature[neighborID] - nodeTemperature;
       nodeFluxDivergence = m_coefficient*kernel*temperatureDifference*quadWeight;
-      TEUCHOS_TEST_FOR_EXCEPT_MSG(!std::isfinite(nodeFluxDivergence), "**** NaN detected in DiffusionMaterial::computeFluxDivergence().\n");
+      TEUCHOS_TEST_FOR_TERMINATION(!std::isfinite(nodeFluxDivergence), "**** NaN detected in DiffusionMaterial::computeFluxDivergence().\n");
       fluxDivergence[iID] += nodeFluxDivergence;
     }
   }

--- a/src/materials/Peridigm_ElasticMaterial.cpp
+++ b/src/materials/Peridigm_ElasticMaterial.cpp
@@ -366,7 +366,7 @@ PeridigmNS::ElasticMaterial::computeAutomaticDifferentiationJacobian(const doubl
     for(int row=0 ; row<numDof ; ++row){
       for(int col=0 ; col<numDof ; ++col){
         value = force_AD[row].dx(col) * cellVolume[row/3];
-        TEUCHOS_TEST_FOR_EXCEPT_MSG(!std::isfinite(value), "**** NaN detected in ElasticMaterial::computeAutomaticDifferentiationJacobian().\n");
+        TEUCHOS_TEST_FOR_TERMINATION(!std::isfinite(value), "**** NaN detected in ElasticMaterial::computeAutomaticDifferentiationJacobian().\n");
         scratchMatrix(row, col) = value;
       }
     }

--- a/src/materials/Peridigm_HypoelasticCorrespondenceMaterial.cpp
+++ b/src/materials/Peridigm_HypoelasticCorrespondenceMaterial.cpp
@@ -597,7 +597,7 @@ PeridigmNS::HypoelasticCorrespondenceMaterial::computeForce(const double dt,
     "**** Error:  HypoelasticCorrespondenceMaterial::computeForce() failed to compute rotation tensor.\n";
   nodeLevelRotationTensorErrorMessage +=
     "****         Note that all nodes must have a minimum of three neighbors.  Is the horizon too small?\n";
-  TEUCHOS_TEST_FOR_EXCEPT_MSG(nodeLevelRotationTensorReturnCode != 0, nodeLevelRotationTensorErrorMessage);
+  TEUCHOS_TEST_FOR_TERMINATION(nodeLevelRotationTensorReturnCode != 0, nodeLevelRotationTensorErrorMessage);
 
   // Compute bond-level values
   int bondLevelRotationTensorReturnCode = CORRESPONDENCE::computeBondLevelUnrotatedRateOfDeformationAndRotationTensor(bondLevelVelocityGradientXX,
@@ -662,7 +662,7 @@ PeridigmNS::HypoelasticCorrespondenceMaterial::computeForce(const double dt,
     "**** Error:  HypoelasticCorrespondenceMaterial::computeForce() failed to compute rotation tensor.\n";
   bondLevelRotationTensorErrorMessage +=
     "****         Note that all nodes must have a minimum of three neighbors.  Is the horizon too small?\n";
-  TEUCHOS_TEST_FOR_EXCEPT_MSG(bondLevelRotationTensorReturnCode != 0, bondLevelRotationTensorErrorMessage);
+  TEUCHOS_TEST_FOR_TERMINATION(bondLevelRotationTensorReturnCode != 0, bondLevelRotationTensorErrorMessage);
 
   // Evaluate the Cauchy stress using the routine implemented in the derived class (specific correspondence material model)
   // The general idea is to compute the stress based on:

--- a/src/materials/Peridigm_Material.cpp
+++ b/src/materials/Peridigm_Material.cpp
@@ -317,7 +317,7 @@ void PeridigmNS::Material::computeFiniteDifferenceJacobian(const double dt,
     // Check for NaNs
     for(unsigned int row=0 ; row<globalIndices.size() ; ++row){
       for(unsigned int col=0 ; col<globalIndices.size() ; ++col){
-        TEUCHOS_TEST_FOR_EXCEPT_MSG(!std::isfinite(scratchMatrix(row, col)), "**** NaN detected in finite-difference Jacobian.\n");
+        TEUCHOS_TEST_FOR_TERMINATION(!std::isfinite(scratchMatrix(row, col)), "**** NaN detected in finite-difference Jacobian.\n");
       }
     }
 

--- a/src/materials/Peridigm_MultiphysicsElasticMaterial.cpp
+++ b/src/materials/Peridigm_MultiphysicsElasticMaterial.cpp
@@ -485,11 +485,11 @@ PeridigmNS::MultiphysicsElasticMaterial::computeAutomaticDifferentiationJacobian
         for(int subcol=0 ; subcol<dofPerNode ; ++subcol){
           for(int subrow=0 ; subrow<(dofPerNode-1) ; ++subrow){
             value = force_AD[row*3/dofPerNode + subrow].dx(col + subcol) * cellVolume[row/dofPerNode];
-            TEUCHOS_TEST_FOR_EXCEPT_MSG(!std::isfinite(value), "**** NaN detected in MultiphysicsElasticMaterial::computeAutomaticDifferentiationJacobian() (internal force).\n");
+            TEUCHOS_TEST_FOR_TERMINATION(!std::isfinite(value), "**** NaN detected in MultiphysicsElasticMaterial::computeAutomaticDifferentiationJacobian() (internal force).\n");
             scratchMatrix(row+subrow, col+subcol) = value;
           }
           value = fluidFlow_AD[row/dofPerNode].dx(col + subcol) * cellVolume[row/dofPerNode];
-          TEUCHOS_TEST_FOR_EXCEPT_MSG(!std::isfinite(value), "**** NaN detected in MultiphysicsElasticMaterial::computeAutomaticDifferentiationJacobian() (fluid flow).\n");
+          TEUCHOS_TEST_FOR_TERMINATION(!std::isfinite(value), "**** NaN detected in MultiphysicsElasticMaterial::computeAutomaticDifferentiationJacobian() (fluid flow).\n");
           scratchMatrix(row +dofPerNode -1, col+subcol) = value;
         }
       }

--- a/src/materials/Peridigm_SpeciesConcentrationMaterial.cpp
+++ b/src/materials/Peridigm_SpeciesConcentrationMaterial.cpp
@@ -124,7 +124,7 @@ PeridigmNS::SpeciesConcentrationMaterial::computeFluxDivergence(const double dt,
       double mu = 1.0; // PLACEHOLDER
       double coefficient = m_coefficient * (1.0 + 0.0001*nodeTemperature); // PLACEHOLDER
       double contribution_to_flux_divergence = mu * coefficient * (concentrationDifference / initialDistance) * neighborVolume;
-      TEUCHOS_TEST_FOR_EXCEPT_MSG(!std::isfinite(contribution_to_flux_divergence), "**** NaN detected in SpeciesConcentrationMaterial::computeFluxDivergence().\n");
+      TEUCHOS_TEST_FOR_TERMINATION(!std::isfinite(contribution_to_flux_divergence), "**** NaN detected in SpeciesConcentrationMaterial::computeFluxDivergence().\n");
       fluxDivergence[iID] += contribution_to_flux_divergence;
     }
   }

--- a/src/materials/Peridigm_VectorPoissonMaterial.cpp
+++ b/src/materials/Peridigm_VectorPoissonMaterial.cpp
@@ -138,8 +138,8 @@ PeridigmNS::VectorPoissonMaterial::computeForce(const double dt,
         temp = (neighborU - nodeU)*kernel;
         nodeForce = temp*neighborVolume;
         neighborForce = -temp*nodeVolume;
-        TEUCHOS_TEST_FOR_EXCEPT_MSG(!std::isfinite(nodeForce), "**** NaN detected in VectorPoissonMaterial::computeForce().\n");
-        TEUCHOS_TEST_FOR_EXCEPT_MSG(!std::isfinite(neighborForce), "**** NaN detected in VectorPoissonMaterial::computeForce().\n");
+        TEUCHOS_TEST_FOR_TERMINATION(!std::isfinite(nodeForce), "**** NaN detected in VectorPoissonMaterial::computeForce().\n");
+        TEUCHOS_TEST_FOR_TERMINATION(!std::isfinite(neighborForce), "**** NaN detected in VectorPoissonMaterial::computeForce().\n");
         f[iID*3+eqn] += nodeForce;
         f[neighborID*3+eqn] += neighborForce;
 

--- a/src/materials/unit_test/utPeridigm_ElasticMaterial.cpp
+++ b/src/materials/unit_test/utPeridigm_ElasticMaterial.cpp
@@ -722,10 +722,10 @@ TEUCHOS_UNIT_TEST(ElasticMaterial, twoPointTangentStiffnessMatrix) {
   for(unsigned int i=0 ; i<6 ; ++i){
     // Allocate space in the global matrix
     int err = tangentFECrsMatrix->InsertGlobalValues(i, numRowNonzeros, (const double*)&zeros[0], (const int*)&indices[0]);
-    TEUCHOS_TEST_FOR_EXCEPT_MSG(err < 0, "**** InsertGlobalValues() returned negative error code.\n");
+    TEUCHOS_TEST_FOR_TERMINATION(err < 0, "**** InsertGlobalValues() returned negative error code.\n");
   }
   int err = tangentFECrsMatrix->GlobalAssemble();
-  TEUCHOS_TEST_FOR_EXCEPT_MSG(err != 0, "**** PeridigmNS::Peridigm::allocateJacobian(), GlobalAssemble() returned nonzero error code.\n");
+  TEUCHOS_TEST_FOR_TERMINATION(err != 0, "**** PeridigmNS::Peridigm::allocateJacobian(), GlobalAssemble() returned nonzero error code.\n");
 
   // create the SerialMatrix that is fed to the material model
   PeridigmNS::SerialMatrix tangentSerialMatrix(tangentFECrsMatrix);

--- a/src/mesh_converter/Peridigm_MeshConverter_Main.cpp
+++ b/src/mesh_converter/Peridigm_MeshConverter_Main.cpp
@@ -68,7 +68,7 @@ void reportExodusError(int errorCode, const char *methodName, const char*exodusM
   std::stringstream ss;
   if(errorCode < 0){ // error
     ss << "MeshConverter -- Error code: " << errorCode << " (" << exodusMethodName << ")";
-    TEUCHOS_TEST_FOR_EXCEPT_MSG(1, ss.str());
+    TEUCHOS_TEST_FOR_TERMINATION(1, ss.str());
   }
   else {
     ss << "MeshConverter -- Warning code: " << errorCode << " (" << exodusMethodName << ")";
@@ -328,7 +328,7 @@ int main(int argc, char *argv[]) {
   }
 
   // Write the block names
-  TEUCHOS_TEST_FOR_EXCEPT_MSG(blocks->size() < 1, "\nMeshConverter, Zero element blocks found!\n");
+  TEUCHOS_TEST_FOR_TERMINATION(blocks->size() < 1, "\nMeshConverter, Zero element blocks found!\n");
   char **block_names = new char*[blocks->size()];
   for(unsigned int i=0 ; i<blocks->size() ; ++i)
     block_names[i] = new char[MAX_STR_LENGTH+1];


### PR DESCRIPTION
As pointed out by @CWillberg in #148 it might happen that the simulation crashs due to a `TEUCHOS_TEST_FOR_EXCEPT_MSG` exception without proper termination. Thus, I exchanged this function as suggested with the `TEUCHOS_TEST_FOR_TERMINATION` function were I was convinced that it is required (everywhere where it might happen that different MPI processes have different values for the variable to check).