### PR TITLE
Print warining when discretization points with zero nieghbours exist (fixes #144)

### DIFF
--- a/src/core/Peridigm.cpp
+++ b/src/core/Peridigm.cpp
@@ -197,7 +197,7 @@ PeridigmNS::Peridigm::Peridigm(const MPI_Comm& comm,
   // The horizon may no longer be specified in the discretization block
   // Throw an exception if the user is running an old input deck with the horizon in the discretization parameter list
   string msg = "\n**** Error, \"Horizon\" is no longer an allowable Discretization parameter.\n";
-  msg +=         "****        A horizon for each block must be specified in the Blocks section.\n";
+         msg +=  "****        A horizon for each block must be specified in the Blocks section.\n";
   TEUCHOS_TEST_FOR_EXCEPT_MSG(discParams->isParameter("Horizon"), msg);
 
   // Check for command to compute horizon-element intersections
@@ -276,8 +276,7 @@ PeridigmNS::Peridigm::Peridigm(const MPI_Comm& comm,
   initializeDiscretization(peridigmDiscretization);
 
   // Instantiate and initialize the boundary and initial condition manager
-  Teuchos::RCP<Teuchos::ParameterList> bcParams =
-    Teuchos::rcpFromRef( peridigmParams->sublist("Boundary Conditions") );
+  Teuchos::RCP<Teuchos::ParameterList> bcParams = Teuchos::rcpFromRef( peridigmParams->sublist("Boundary Conditions") );
 
   // Set a flag for creation of the RANK_DEFICIENT_NODES node set if the simulation
   // uses implicit time integration and has bond failure
@@ -292,8 +291,7 @@ PeridigmNS::Peridigm::Peridigm(const MPI_Comm& comm,
       bcParams->set<bool>("Create Node Set For Rank Deficient Nodes", true);
   }
 
-  boundaryAndInitialConditionManager =
-    Teuchos::RCP<BoundaryAndInitialConditionManager>(new BoundaryAndInitialConditionManager(*bcParams, this));
+  boundaryAndInitialConditionManager = Teuchos::RCP<BoundaryAndInitialConditionManager>(new BoundaryAndInitialConditionManager(*bcParams, this));
 
   boundaryAndInitialConditionManager->initialize(peridigmDiscretization);
 
@@ -391,7 +389,7 @@ PeridigmNS::Peridigm::Peridigm(const MPI_Comm& comm,
   double minElementRadius = peridigmDiscretization->getMinElementRadius();
   double defaultFiniteDifferenceProbeLength = 1.0e-6*minElementRadius;
 
-  // Obtain parameter lists and factories for material models ane damage models
+  // Obtain parameter lists and factories for material models and damage models
   // Material models
   Teuchos::ParameterList materialParams = peridigmParams->sublist("Materials", true);
   MaterialFactory materialFactory;
@@ -783,7 +781,7 @@ PeridigmNS::Peridigm::Peridigm(const MPI_Comm& comm,
       cout << "\n  number of rows = " << tangent->NumGlobalRows() << endl;
       if(numMultiphysDoFs > 0)
         cout << "  of those rows, " << numMultiphysDoFs << " are interspersed multiphysics terms." << endl;
-      cout << "  number of nonzeros = " << tangent->NumGlobalNonzeros() << "\n" << endl;
+      cout << "  number of nonzeros = " << tangent->NumGlobalNonzeros64() << "\n" << endl;
     }
     jacobianType = PeridigmNS::Material::FULL_MATRIX;
   }
@@ -806,7 +804,7 @@ PeridigmNS::Peridigm::Peridigm(const MPI_Comm& comm,
     PeridigmNS::Timer::self().stopTimer("Allocate Global Block Diagonal Tangent");
     if(peridigmComm->MyPID() == 0 && !allocateTangent){
       cout << "\n  number of rows = " << blockDiagonalTangent->NumGlobalRows() << endl;
-      cout << "  number of nonzeros = " << blockDiagonalTangent->NumGlobalNonzeros() << "\n" << endl;
+      cout << "  number of nonzeros = " << blockDiagonalTangent->NumGlobalNonzeros64() << "\n" << endl;
     }
     if(jacobianType == PeridigmNS::Material::UNDEFINED)
       jacobianType = PeridigmNS::Material::BLOCK_DIAGONAL;
@@ -903,7 +901,7 @@ void PeridigmNS::Peridigm::initializeDiscretization(Teuchos::RCP<Discretization>
     }
   }
   if(analysisHasBondAssociatedHypoelasticModel){
-    damage = Teuchos::rcp((*oneDimensionalMothership)(9), false);              // damage
+    damage = Teuchos::rcp((*oneDimensionalMothership)(9), false);               // damage
     jacobianDeterminant = Teuchos::rcp((*oneDimensionalMothership)(10), false); // jacobian determinant (J)
     weightedVolume = Teuchos::rcp((*oneDimensionalMothership)(11), false);      // weighted volume
     damage->PutScalar(0.0);
@@ -926,7 +924,7 @@ void PeridigmNS::Peridigm::initializeDiscretization(Teuchos::RCP<Discretization>
   deltaU = Teuchos::rcp((*threeDimensionalMothership)(8), false);        // increment in displacement (used only for implicit time integration)
   scratch = Teuchos::rcp((*threeDimensionalMothership)(9), false);       // scratch space
   if(analysisHasBondAssociatedHypoelasticModel){
-    velocityGradientX = Teuchos::rcp((*threeDimensionalMothership)(10), false);  // velocity gradient XX XY XZ (L)
+    velocityGradientX = Teuchos::rcp((*threeDimensionalMothership)(10), false); // velocity gradient XX XY XZ (L)
     velocityGradientY = Teuchos::rcp((*threeDimensionalMothership)(11), false); // velocity gradient YX YY YZ (L)
     velocityGradientZ = Teuchos::rcp((*threeDimensionalMothership)(12), false); // velocity gradient ZX ZY ZZ (L)
   }
@@ -1003,6 +1001,7 @@ std::string getCmdOutput(const std::string& mStr)
   pclose(pipe);
   return result;
 }
+
 std::string firstNumbersSring(std::string const & str)
 {
   std::size_t const n = str.find_first_of("0123456789");
@@ -1013,6 +1012,7 @@ std::string firstNumbersSring(std::string const & str)
   }
   return std::string();
 }
+
 void PeridigmNS::Peridigm::InitializeRestart() {
   Teuchos::RCP<Teuchos::ParameterList> firstSolver = solverParameters[0];
   std::string str;
@@ -1118,6 +1118,7 @@ restartFiles["deltaU"] = pathname;
 sprintf(pathname,"%s/scratch.mat",restart_directory_namePtr);
 restartFiles["scratch"] = pathname;
 }
+
 void PeridigmNS::Peridigm::instantiateComputeManager(Teuchos::RCP<Discretization> peridigmDiscretization) {
 
   Teuchos::RCP<Teuchos::ParameterList> computeParams = Teuchos::rcp( new Teuchos::ParameterList("Compute Manager") );

--- a/src/core/Peridigm_Factory.cpp
+++ b/src/core/Peridigm_Factory.cpp
@@ -76,10 +76,10 @@ Teuchos::RCP<PeridigmNS::Peridigm> PeridigmNS::PeridigmFactory::create(const std
     Teuchos::updateParametersFromYamlFile(inputFile, peridigmParamsPtr);
 #else
     std::string msg = "**** Error, YAML reader not available.  Trilinos must be compiled with YAML support to enable this feature.\n";
-    msg += "**** You must obtain the yaml-cpp library, build it, and re-compile Trilinos with the the following flags:\n";
-    msg += "****   TPL_ENABLE_yaml-cpp:BOOL=ON\n";
-    msg += "****   yaml-cpp_INCLUDE_DIRS:PATH=/path/to/yaml/include\n";
-    msg += "****   yaml-cpp_LIBRARY_DIRS:PATH=/path/to/yaml/lib\n";
+                msg += "**** You must obtain the yaml-cpp library, build it, and re-compile Trilinos with the the following flags:\n";
+                msg += "****   TPL_ENABLE_yaml-cpp:BOOL=ON\n";
+                msg += "****   yaml-cpp_INCLUDE_DIRS:PATH=/path/to/yaml/include\n";
+                msg += "****   yaml-cpp_LIBRARY_DIRS:PATH=/path/to/yaml/lib\n";
     throw std::runtime_error(msg);
 #endif
   }

--- a/src/io/discretization/Peridigm_AlbanyDiscretization.hpp
+++ b/src/io/discretization/Peridigm_AlbanyDiscretization.hpp
@@ -193,9 +193,6 @@ namespace PeridigmNS {
 
     //! Discretization parameter controling the formation of bonds
     std::string bondFilterCommand;
-
-    //! Epetra communicator
-    Teuchos::RCP<const Epetra_Comm> comm;
   };
 }
 

--- a/src/io/discretization/Peridigm_Discretization.hpp
+++ b/src/io/discretization/Peridigm_Discretization.hpp
@@ -63,9 +63,10 @@ namespace PeridigmNS {
   public:
 
     //! Constructor
-    Discretization() :
+    Discretization(const Teuchos::RCP<const Epetra_Comm>& epetraComm) :
       elementBlocks(Teuchos::rcp(new std::map< std::string, std::vector<int> >())),
-      nodeSets(Teuchos::rcp(new std::map< std::string, std::vector<int> >()))
+      nodeSets(Teuchos::rcp(new std::map< std::string, std::vector<int> >())),
+      comm(epetraComm)
     {}
 
     //! Destructor
@@ -161,6 +162,13 @@ namespace PeridigmNS {
     //! Get the block id for a given block name
     int blockNameToBlockId(std::string blockName) const;
 
+    //! Create the bondMap, a local map used for constitutive data stored on bonds.
+    void createBondMapAndCheckForZeroNeighbors(Teuchos::RCP<Epetra_BlockMap>& bondMap,
+                                               const Teuchos::RCP<Epetra_BlockMap> oneDimensionalMap,
+                                               const Teuchos::RCP<PeridigmNS::NeighborhoodData> neighborhoodData,
+                                               unsigned int & numBonds,
+                                               unsigned int & maxNumBondsPerElem) const;
+
   protected:
 
     //! Get the overlap map.
@@ -186,6 +194,9 @@ namespace PeridigmNS {
     Teuchos::RCP< std::map< std::string, int> > nodeSetIds;
 
     std::vector< std::shared_ptr<PdBondFilter::BondFilter> > bondFilters;
+
+    //! Epetra communicator
+    Teuchos::RCP<const Epetra_Comm> comm;
 
   private:
 

--- a/src/io/discretization/Peridigm_ExodusDiscretization.hpp
+++ b/src/io/discretization/Peridigm_ExodusDiscretization.hpp
@@ -234,9 +234,6 @@ namespace PeridigmNS {
 
     //! Discretization parameter controling the formation of bonds
     std::string bondFilterCommand;
-
-    //! Epetra communicator
-    Teuchos::RCP<const Epetra_Comm> comm;
   };
 }
 

--- a/src/io/discretization/Peridigm_PdQuickGridDiscretization.hpp
+++ b/src/io/discretization/Peridigm_PdQuickGridDiscretization.hpp
@@ -183,9 +183,6 @@ namespace PeridigmNS {
 
     //! Number of Processors
     unsigned int numPID;
-
-    //! Epetra communicator
-    Teuchos::RCP<const Epetra_Comm> comm;
   };
 }
 

--- a/src/io/discretization/Peridigm_TextFileDiscretization.hpp
+++ b/src/io/discretization/Peridigm_TextFileDiscretization.hpp
@@ -191,9 +191,6 @@ namespace PeridigmNS {
 
     //! Discretization parameter controling the formation of bonds
     std::string bondFilterCommand;
-
-    //! Epetra communicator
-    Teuchos::RCP<const Epetra_Comm> comm;
   };
 }
 


### PR DESCRIPTION
I faced the problem that quasi-static simulations crashed for some discretizations. It became apparent that the reason were discretization points that have no neighbour within its horizon (see #144).
To support future users in finding the reason when they might face the same problem I implemented a check for zero-neighbourhood when the discretization is read. If so a warning message is printed to the user with the hint that this might result in problems downstream.
Following changes were done:
- When the bond map for the discretization is created it is checked for points with zero-neighbourhood. If so, a warning is printed for the user to the stdout with the global id of this point and its model coordinates.
- Some refactoring was necessary for the PdQuickGrid and TextFile discretization. Furthermore the function was renamed to emphasize its functionality.
- The integer overflow for the number of global non-zeros in the tangent matrix for large models has been fixed.