### PR TITLE
Fixed a bug related to restart for explicit solver

### DIFF
--- a/src/core/Peridigm.hpp
+++ b/src/core/Peridigm.hpp
@@ -417,6 +417,9 @@ namespace PeridigmNS {
     //! Multiphysics flag
     bool analysisHasMultiphysics;
 
+    //! Read restart flag
+    bool analysisHasReadRestart;
+
     //! Flag for computing element-sphere intersections
     bool computeIntersections;
 


### PR DESCRIPTION
There was a bug for the explicit solver that only shows up if restart is 
invoked (the subsequent runs in restart). When a case is read from 
restart files, the last step p is currently re-run without proper enforcement 
of the boundary conditions in the initialization step. This would result in 
wrong calculations. Since the states N and NP1 were already swapped 
before the restart files were written, we can just skip to the next step. A 
flag is added to bypass the force calculation in the initialization step when 
restart files are read.