### PR TITLE
Enable Fortran within the CMake file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@
 
 Cmake_minimum_required (VERSION 2.6)
 
+enable_language( Fortran )
+
 enable_testing ()
 project(Peridigm)
 


### PR DESCRIPTION
A Fortran routine can be called from a C++ file.
Just note that it needs to be explicitly included in the corresponding
CMakeLists.txt file (for example, within src/materials if it's there).