### PR TITLE
Added oversubscribe flag to MPI execution commands

### DIFF
--- a/test/verification/ElasticBondBased/ElasticBondBased2DPlaneStrain/np4/ElasticBondBased2DPlaneStrain.py
+++ b/test/verification/ElasticBondBased/ElasticBondBased2DPlaneStrain/np4/ElasticBondBased2DPlaneStrain.py
@@ -34,7 +34,7 @@ if __name__ == "__main__":
         os.remove(file)
 
     # run Peridigm
-    command = ["mpiexec", "-np", "4", "../../../../../src/Peridigm", "../" + base_name + ".yaml"]
+    command = ["mpiexec", "-np", "4", "--oversubscribe", "../../../../../src/Peridigm", "../" + base_name + ".yaml"]
     p = Popen(command, stdout=logfile, stderr=logfile)
     return_code = p.wait()
     if return_code != 0:

--- a/test/verification/ElasticBondBased/ElasticBondBased2DPlaneStress/np4/ElasticBondBased2DPlaneStress.py
+++ b/test/verification/ElasticBondBased/ElasticBondBased2DPlaneStress/np4/ElasticBondBased2DPlaneStress.py
@@ -34,7 +34,7 @@ if __name__ == "__main__":
         os.remove(file)
 
     # run Peridigm
-    command = ["mpiexec", "-np", "4", "../../../../../src/Peridigm", "../" + base_name + ".yaml"]
+    command = ["mpiexec", "-np", "4", "--oversubscribe", "../../../../../src/Peridigm", "../" + base_name + ".yaml"]
     p = Popen(command, stdout=logfile, stderr=logfile)
     return_code = p.wait()
     if return_code != 0:

--- a/test/verification/ElasticBondBased/ElasticBondBased3D/np4/ElasticBondBased3D.py
+++ b/test/verification/ElasticBondBased/ElasticBondBased3D/np4/ElasticBondBased3D.py
@@ -34,7 +34,7 @@ if __name__ == "__main__":
         os.remove(file)
 
     # run Peridigm
-    command = ["mpiexec", "-np", "4", "../../../../../src/Peridigm", "../" + base_name + ".yaml"]
+    command = ["mpiexec", "-np", "4", "--oversubscribe", "../../../../../src/Peridigm", "../" + base_name + ".yaml"]
     p = Popen(command, stdout=logfile, stderr=logfile)
     return_code = p.wait()
     if return_code != 0:

--- a/test/verification/PredictorFromPreviousSolver/np3/PredictorFromPreviousSolverNOXFalse.py
+++ b/test/verification/PredictorFromPreviousSolver/np3/PredictorFromPreviousSolverNOXFalse.py
@@ -33,7 +33,7 @@ if __name__ == "__main__":
         os.remove(file)
 
     # run Peridigm
-    command = ["mpirun", "-n", "3", "../../../../src/Peridigm", "../"+base_name+".yaml"]
+    command = ["mpirun", "-n", "3", "--oversubscribe", "../../../../src/Peridigm", "../"+base_name+".yaml"]
     p = Popen(command, stdout=logfile, stderr=logfile)
     return_code = p.wait()
     if return_code != 0:

--- a/test/verification/PredictorFromPreviousSolver/np3/PredictorFromPreviousSolverNOXTrue.py
+++ b/test/verification/PredictorFromPreviousSolver/np3/PredictorFromPreviousSolverNOXTrue.py
@@ -33,7 +33,7 @@ if __name__ == "__main__":
         os.remove(file)
 
     # run Peridigm
-    command = ["mpirun", "-n", "3", "../../../../src/Peridigm", "../"+base_name+".yaml"]
+    command = ["mpirun", "-n", "3", "--oversubscribe", "../../../../src/Peridigm", "../"+base_name+".yaml"]
     p = Popen(command, stdout=logfile, stderr=logfile)
     return_code = p.wait()
     if return_code != 0:

--- a/test/verification/PredictorFromPreviousSolver/np3/PredictorFromPreviousSolverQSFalse.py
+++ b/test/verification/PredictorFromPreviousSolver/np3/PredictorFromPreviousSolverQSFalse.py
@@ -33,7 +33,7 @@ if __name__ == "__main__":
         os.remove(file)
 
     # run Peridigm
-    command = ["mpirun", "-n", "3", "../../../../src/Peridigm", "../"+base_name+".yaml"]
+    command = ["mpirun", "-n", "3", "--oversubscribe", "../../../../src/Peridigm", "../"+base_name+".yaml"]
     p = Popen(command, stdout=logfile, stderr=logfile)
     return_code = p.wait()
     if return_code != 0:

--- a/test/verification/PredictorFromPreviousSolver/np3/PredictorFromPreviousSolverQSTrue.py
+++ b/test/verification/PredictorFromPreviousSolver/np3/PredictorFromPreviousSolverQSTrue.py
@@ -33,7 +33,7 @@ if __name__ == "__main__":
         os.remove(file)
 
     # run Peridigm
-    command = ["mpirun", "-n", "3", "../../../../src/Peridigm", "../"+base_name+".yaml"]
+    command = ["mpirun", "-n", "3", "--oversubscribe", "../../../../src/Peridigm", "../"+base_name+".yaml"]
     p = Popen(command, stdout=logfile, stderr=logfile)
     return_code = p.wait()
     if return_code != 0:


### PR DESCRIPTION
In a view test the python scripts do not contain the ``--oversubscribe`` flag for ``mpirun`` which might cause in a failed CI.