### PR TITLE
Fix for building Peridigm with Trilinos14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@
 Cmake_minimum_required (VERSION 3.3)
 cmake_policy(SET CMP0057 NEW)
 
+set(CMAKE_CXX_STANDARD 17)
+
 enable_language( Fortran )
 
 enable_testing ()
@@ -34,6 +36,16 @@ find_library(Lapack_LIBRARY
 )
 set(BlasLapack_Libraries ${blas} ${lapack})
 
+find_library(Netcdf_LIBRARY
+   NAMES Netcdf
+   PATHS ${NETCDF_LIBRARY_DIRS}
+)
+
+find_library( yamlcpp
+  NAMES yaml-cpp
+  PATHS /usr/lib64
+  )
+
 #
 # DAKOTA configuration
 #
@@ -41,6 +53,8 @@ option (USE_DAKOTA
    "Enable tests and functionality that depend on a DAKOTA installation."
    OFF
 )
+
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 #
 # Trilinos configuration
@@ -52,14 +66,11 @@ MESSAGE("Trilinos installation:")
 MESSAGE("   Trilinos_DIR = ${Trilinos_DIR}")
 MESSAGE("   Trilinos_VERSION = ${Trilinos_VERSION}")
 MESSAGE("   Trilinos_PACKAGE_LIST = ${Trilinos_PACKAGE_LIST}")
-MESSAGE("   Trilinos_TPL_LIST = ${Trilinos_TPL_LIST}")
-#MESSAGE("   Trilinos_TPL_INCLUDE_DIRS = ${Trilinos_TPL_INCLUDE_DIRS}")
-#MESSAGE("   Trilinos_TPL_LIBRARIES = ${Trilinos_TPL_LIBRARIES}")
-MESSAGE("   Trilinos_TPL_LIBRARY_DIRS = ${Trilinos_TPL_LIBRARY_DIRS}")
 MESSAGE("   Trilinos_BUILD_SHARED_LIBS = ${Trilinos_BUILD_SHARED_LIBS}")
 MESSAGE("   Trilinos_CXX_COMPILER_FLAGS = ${Trilinos_CXX_COMPILER_FLAGS}")
 # Hack for now until Trilinos exports cmake variable for binaries directory
-SET(Trilinos_BINARY_PATH ${Trilinos_LIBRARY_DIRS}/../bin)
+SET(Trilinos_BINARY_PATH ${Trilinos_INCLUDE_DIRS}/../bin)
+MESSAGE("   Trilinos_BINARY_PATH = ${Trilinos_BINARY_PATH}")
 #
 # Remove PyTrilinos if it's there to avoid errors, we don't use it in Peridigm
 #
@@ -68,22 +79,13 @@ LIST(REMOVE_ITEM Trilinos_LIBRARIES "pytrilinos")
 # verbose output
 #MESSAGE("   Trilinos_LIBRARIES = ${Trilinos_LIBRARIES}")
 MESSAGE("   Trilinos_INCLUDE_DIRS = ${Trilinos_INCLUDE_DIRS}")
-MESSAGE("   Trilinos_LIBRARY_DIRS = ${Trilinos_LIBRARY_DIRS}")
 MESSAGE("")
-
-# Check for netcdf
-LIST(FIND Trilinos_TPL_LIST Netcdf Netcdf_Package_Index)
-IF(Netcdf_Package_Index LESS 0)
-  MESSAGE("FATAL_ERROR \n\nError:  Netcdf NOT found.  Netcdf is a REQUIRED Trilinos TPL.\n\n")
-ENDIF()
 
 # Check for yaml
 LIST(FIND Trilinos_TPL_LIST yaml-cpp yaml-cpp_Package_Index)
-IF(yaml-cpp_Package_Index GREATER -1)
-    MESSAGE("-- Trilinos was compiled with TPL_ENABLE_yaml-cpp.\n\n   Will compile Peridigm to support YAML input files.\n\n")
-    ADD_DEFINITIONS(-DUSE_YAML)
-    SET(HAVE_YAML TRUE)
-ENDIF()
+ADD_DEFINITIONS(-DUSE_YAML)
+SET(HAVE_YAML TRUE)
+
 
 #
 # Enable performance testing
@@ -100,16 +102,23 @@ IF (ALBANY_SEACAS)
        SEACAS_EPU
        NAMES epu
        PATHS ${Trilinos_BIN_DIRS} ENV PATH
-  )
-  find_program(
-       SEACAS_EXODIFF
-       NAMES exodiff
-       PATHS ${Trilinos_BIN_DIRS} ENV PATH
-  )
-  find_program(
-       SEACAS_ALGEBRA
-       NAMES algebra
-       PATHS ${Trilinos_BIN_DIRS} ENV PATH
+      # PATHS /opt/apps/libs/trilinos-14.4.0-1-peri-mpi/bin
+      REQUIRED
+)
+find_program(
+      SEACAS_EXODIFF
+      NAMES exodiff
+      PATHS ${Trilinos_BIN_DIRS} ENV PATH
+      # PATHS /opt/apps/libs/trilinos-14.4.0-1-peri-mpi/bin
+      REQUIRED
+)
+find_program(
+      SEACAS_ALGEBRA
+      NAMES algebra
+      PATHS ${Trilinos_BIN_DIRS} ENV PATH
+      # PATHS /opt/apps/libs/trilinos-14.4.0-1-peri-mpi/bin
+      REQUIRED
+      
   )
 ENDIF()
 

--- a/src/api/Peridigm_API.cpp
+++ b/src/api/Peridigm_API.cpp
@@ -65,7 +65,18 @@
   extern "C" {
 #endif
 
-using namespace std;
+using std::vector;
+using std::pair;
+using std::set;
+using std::copy;
+using std::cout;
+using std::ofstream;
+using std::istringstream;
+using std::stringstream;
+using std::endl;
+using std::setprecision;
+using std::string;
+using std::back_inserter;
 
 PD_LIB_DLL_EXPORT const int run_peridigm(int argc, char *argv[], const bool finalize){
   static bool initialized = false;

--- a/src/compute/Peridigm_Compute_Block_Data.cpp
+++ b/src/compute/Peridigm_Compute_Block_Data.cpp
@@ -50,7 +50,6 @@
 #include "Peridigm_Compute_Block_Data.hpp"
 #include "Peridigm_Field.hpp"
 
-using namespace std;
 
 //! Standard constructor.
 PeridigmNS::Compute_Block_Data::Compute_Block_Data(Teuchos::RCP<const Teuchos::ParameterList> params,

--- a/src/compute/Peridigm_Compute_Bond_Visualization.cpp
+++ b/src/compute/Peridigm_Compute_Bond_Visualization.cpp
@@ -49,7 +49,11 @@
 #include <sstream>
 #include <fstream>
 
-using namespace std;
+using std::vector;
+using std::endl;
+using std::stringstream;
+using std::ofstream;
+using std::pair;
 
 PeridigmNS::Compute_Bond_Visualization::Compute_Bond_Visualization(Teuchos::RCP<const Teuchos::ParameterList> params,
                                                                    Teuchos::RCP<const Epetra_Comm> epetraComm_,

--- a/src/compute/Peridigm_Compute_Node_Set_Data.cpp
+++ b/src/compute/Peridigm_Compute_Node_Set_Data.cpp
@@ -51,8 +51,6 @@
 #include "Peridigm_Discretization.hpp"
 #include "Peridigm_Field.hpp"
 
-using namespace std;
-
 //! Standard constructor.
 PeridigmNS::Compute_Node_Set_Data::Compute_Node_Set_Data(Teuchos::RCP<const Teuchos::ParameterList> params,
                                                          Teuchos::RCP<const Epetra_Comm> epetraComm_,

--- a/src/compute/Peridigm_Compute_Nonlinear_Solver_Iterations.cpp
+++ b/src/compute/Peridigm_Compute_Nonlinear_Solver_Iterations.cpp
@@ -50,8 +50,6 @@
 #include "Peridigm_Compute_Nonlinear_Solver_Iterations.hpp"
 #include "Peridigm_Field.hpp"
 
-using namespace std;
-
 //! Standard constructor.
 PeridigmNS::Compute_Nonlinear_Solver_Iterations::Compute_Nonlinear_Solver_Iterations(Teuchos::RCP<const Teuchos::ParameterList> params,
                                                                                      Teuchos::RCP<const Epetra_Comm> epetraComm_,

--- a/src/contact/Peridigm_ContactModelFactory.cpp
+++ b/src/contact/Peridigm_ContactModelFactory.cpp
@@ -50,7 +50,7 @@
 #include "Peridigm_ShortRangeForceContactModel.hpp"
 #include "Peridigm_UserDefinedTimeDependentShortRangeForceContactModel.hpp"
 
-using namespace std;
+using std::string;
 
 Teuchos::RCP<PeridigmNS::ContactModel>
 PeridigmNS::ContactModelFactory::create(const Teuchos::ParameterList& contactModelParams)

--- a/src/core/Peridigm.cpp
+++ b/src/core/Peridigm.cpp
@@ -100,7 +100,19 @@
 #include "EpetraExt_VectorOut.h"
 #include <sys/stat.h>
 
-using namespace std;
+using std::vector;
+using std::pair;
+using std::map;
+using std::copy;
+using std::cout;
+using std::ifstream;
+using std::ofstream;
+using std::istringstream;
+using std::stringstream;
+using std::endl;
+using std::setprecision;
+using std::istream_iterator;
+using std::back_inserter;
 
 PeridigmNS::Peridigm::Peridigm(const MPI_Comm& comm,
                                Teuchos::RCP<Teuchos::ParameterList> params,

--- a/src/core/Peridigm.hpp
+++ b/src/core/Peridigm.hpp
@@ -646,7 +646,7 @@ namespace PeridigmNS {
     string textMultiphysDoFs;
 
     // Map for restart files
-    map<string, string> restartFiles;
+    std::map<string, string> restartFiles;
 
     // Set name of restart files
     void setRestartNames(char const * path);

--- a/src/core/Peridigm_Block.cpp
+++ b/src/core/Peridigm_Block.cpp
@@ -51,7 +51,7 @@
 #include <set>
 #include <sstream>
 
-using namespace std;
+using std::vector;
 
 void PeridigmNS::Block::initialize(Teuchos::RCP<const Epetra_BlockMap> globalOwnedScalarPointMap,
                                    Teuchos::RCP<const Epetra_BlockMap> globalOverlapScalarPointMap,

--- a/src/core/Peridigm_BlockBase.cpp
+++ b/src/core/Peridigm_BlockBase.cpp
@@ -50,7 +50,17 @@
 #include <vector>
 #include <set>
 
-using namespace std;
+using std::vector;
+using std::pair;
+using std::set;
+using std::copy;
+using std::cout;
+using std::ofstream;
+using std::istringstream;
+using std::stringstream;
+using std::endl;
+using std::setprecision;
+using std::string;
 
 PeridigmNS::BlockBase::BlockBase(std::string blockName_, int blockID_, Teuchos::ParameterList& blockParams_)
   : blockName(blockName_), blockID(blockID_), blockParams(blockParams_)

--- a/src/core/Peridigm_BoundaryAndInitialConditionManager.cpp
+++ b/src/core/Peridigm_BoundaryAndInitialConditionManager.cpp
@@ -55,7 +55,20 @@
 #include "Peridigm_Enums.hpp"
 #include "Peridigm.hpp"
 
-using namespace std;
+using std::vector;
+using std::map;
+using std::pair;
+using std::copy;
+using std::cout;
+using std::ofstream;
+using std::ifstream;
+using std::istringstream;
+using std::stringstream;
+using std::endl;
+using std::setprecision;
+using std::string;
+using std::istream_iterator;
+using std::back_inserter;
 
 PeridigmNS::BoundaryAndInitialConditionManager::BoundaryAndInitialConditionManager(const Teuchos::ParameterList& boundaryAndInitialConditionParams, Peridigm * peridigm_)
   : params(boundaryAndInitialConditionParams), peridigm(peridigm_), createRankDeficientNodesNodeSet(false)

--- a/src/core/Peridigm_BoundaryAndInitialConditionManager.hpp
+++ b/src/core/Peridigm_BoundaryAndInitialConditionManager.hpp
@@ -129,13 +129,13 @@ namespace PeridigmNS {
     bool createRankDeficientNodesNodeSet;
 
     //! Set of all the boundary conditions
-    vector<Teuchos::RCP<BoundaryCondition> > boundaryConditions;
+    std::vector<Teuchos::RCP<BoundaryCondition> > boundaryConditions;
 
     //! Set of all the initial conditions
-    vector<Teuchos::RCP<BoundaryCondition> > initialConditions;
+    std::vector<Teuchos::RCP<BoundaryCondition> > initialConditions;
 
     //! Set of all the force contributions
-    vector<Teuchos::RCP<BoundaryCondition> > forceContributions;
+    std::vector<Teuchos::RCP<BoundaryCondition> > forceContributions;
 
   private:
 

--- a/src/core/Peridigm_BoundaryCondition.cpp
+++ b/src/core/Peridigm_BoundaryCondition.cpp
@@ -50,8 +50,16 @@
 #include <cmath>
 #include <sstream>
 
-
-using namespace std;
+using std::vector;
+using std::pair;
+using std::copy;
+using std::cout;
+using std::ofstream;
+using std::istringstream;
+using std::stringstream;
+using std::endl;
+using std::setprecision;
+using std::string;
 
 PeridigmNS::BoundaryCondition::BoundaryCondition(const string & name_,
                                                  const Teuchos::ParameterList& bcParams_,

--- a/src/core/Peridigm_BoundaryCondition.hpp
+++ b/src/core/Peridigm_BoundaryCondition.hpp
@@ -58,7 +58,7 @@
 #include "FunctionRTC.hh"
 #endif
 
-using namespace std;
+using std::string;
 
 namespace PeridigmNS {
 

--- a/src/core/Peridigm_ComputeManager.cpp
+++ b/src/core/Peridigm_ComputeManager.cpp
@@ -53,7 +53,18 @@
 #include "Peridigm_ComputeManager.hpp"
 #include "compute_includes.hpp"
 
-using namespace std;
+using std::vector;
+using std::pair;
+using std::set;
+using std::copy;
+using std::cout;
+using std::ofstream;
+using std::istringstream;
+using std::stringstream;
+using std::endl;
+using std::setprecision;
+using std::string;
+using std::back_inserter;
 
 PeridigmNS::ComputeManager::ComputeManager( Teuchos::RCP<Teuchos::ParameterList> params, Teuchos::RCP<const Epetra_Comm> epetraComm, Teuchos::RCP<const Teuchos::ParameterList> computeClassGlobalParams ) {
 

--- a/src/core/Peridigm_ContactBlock.cpp
+++ b/src/core/Peridigm_ContactBlock.cpp
@@ -50,7 +50,8 @@
 #include <vector>
 #include <set>
 
-using namespace std;
+using std::vector;
+
 
 void PeridigmNS::ContactBlock::initialize(Teuchos::RCP<const Epetra_BlockMap> globalOwnedScalarPointMap,
                                    Teuchos::RCP<const Epetra_BlockMap> globalOverlapScalarPointMap,

--- a/src/core/Peridigm_ContactManager.cpp
+++ b/src/core/Peridigm_ContactManager.cpp
@@ -55,7 +55,20 @@
 #include <sstream>
 #include <iterator>
 
-using namespace std;
+using std::vector;
+using std::map;
+using std::pair;
+using std::set;
+using std::copy;
+using std::cout;
+using std::ofstream;
+using std::istringstream;
+using std::stringstream;
+using std::endl;
+using std::setprecision;
+using std::string;
+using std::istream_iterator;
+using std::back_inserter;
 
 //#define NEW_STUFF 1
 

--- a/src/core/Peridigm_DataManager.cpp
+++ b/src/core/Peridigm_DataManager.cpp
@@ -51,7 +51,11 @@
 #include "Peridigm_DataManager.hpp"
 #include "Peridigm_Field.hpp"
 
-using namespace std;
+using std::vector;
+using std::map;
+using std::pair;
+using std::cout;
+using std::stringstream;
 
 std::vector<int> PeridigmNS::DataManager::allGlobalFieldIds;
 Teuchos::RCP<const Epetra_BlockMap> PeridigmNS::DataManager::scalarGlobalMap;

--- a/src/core/Peridigm_Field.cpp
+++ b/src/core/Peridigm_Field.cpp
@@ -49,7 +49,17 @@
 #include <Teuchos_Assert.hpp>
 #include <algorithm>
 
-using namespace std;
+using std::vector;
+using std::map;
+using std::pair;
+using std::copy;
+using std::cout;
+using std::ofstream;
+using std::istringstream;
+using std::stringstream;
+using std::endl;
+using std::setprecision;
+using std::string;
 
 int PeridigmNS::PeridigmField::variableDimension(Length length){
   int varDimension;

--- a/src/core/Peridigm_HorizonManager.cpp
+++ b/src/core/Peridigm_HorizonManager.cpp
@@ -50,7 +50,20 @@
 #include <Teuchos_Exceptions.hpp>
 #include <iterator>
 
-using namespace std;
+using std::vector;
+using std::map;
+using std::pair;
+using std::copy;
+using std::cout;
+using std::string;
+using std::ofstream;
+using std::istringstream;
+using std::stringstream;
+using std::endl;
+using std::setprecision;
+using std::istream_iterator;
+using std::back_inserter;
+
 
 PeridigmNS::HorizonManager::HorizonManager() {
   // set up RTCompiler

--- a/src/core/Peridigm_InfluenceFunction.cpp
+++ b/src/core/Peridigm_InfluenceFunction.cpp
@@ -47,8 +47,6 @@
 
 #include "Peridigm_InfluenceFunction.hpp"
 
-using namespace std;
-
 PG_RuntimeCompiler::Function PeridigmNS::InfluenceFunction::rtcFunction(3, "rtcInfluenceFunctionUserDefinedFunction");
 
 PeridigmNS::InfluenceFunction& PeridigmNS::InfluenceFunction::self() {

--- a/src/core/Peridigm_Main.cpp
+++ b/src/core/Peridigm_Main.cpp
@@ -63,7 +63,16 @@
 #include "Peridigm_Factory.hpp"
 #include "Peridigm_Timer.hpp"
 
-using namespace std;
+using std::vector;
+using std::pair;
+using std::copy;
+using std::cout;
+using std::ofstream;
+using std::istringstream;
+using std::stringstream;
+using std::endl;
+using std::setprecision;
+using std::string;
 
 /*!
  * \brief The main routine for Peridigm: A parallel, multi-physics,

--- a/src/core/Peridigm_SerialMatrix.cpp
+++ b/src/core/Peridigm_SerialMatrix.cpp
@@ -54,7 +54,15 @@
 
 #include "Peridigm_SerialMatrix.hpp"
 
-using namespace std;
+using std::vector;
+using std::map;
+using std::pair;
+using std::copy;
+using std::cout;
+using std::ofstream;
+using std::istringstream;
+using std::endl;
+using std::setprecision;
 
 PeridigmNS::SerialMatrix::SerialMatrix(Teuchos::RCP<Epetra_FECrsMatrix> epetraFECrsMatrix)
   : FECrsMatrix(epetraFECrsMatrix)

--- a/src/core/Peridigm_State.cpp
+++ b/src/core/Peridigm_State.cpp
@@ -52,7 +52,16 @@
 #include <sstream>
 #include <EpetraExt_MultiVectorOut.h>
 #include <EpetraExt_MultiVectorIn.h>
-using namespace std;
+using std::vector;
+using std::pair;
+using std::copy;
+using std::cout;
+using std::ofstream;
+using std::istringstream;
+using std::stringstream;
+using std::endl;
+using std::setprecision;
+using std::string;
 
 void PeridigmNS::State::allocatePointData(PeridigmField::Length length,
                                           vector<int> fieldIds,

--- a/src/core/Peridigm_Timer.cpp
+++ b/src/core/Peridigm_Timer.cpp
@@ -9,7 +9,20 @@
 #include <Teuchos_GlobalMPISession.hpp>
 #include <Teuchos_RCP.hpp>
 
-using namespace std;
+using std::ostream;
+using std::vector;
+using std::map;
+using std::pair;
+using std::copy;
+using std::cout;
+using std::ofstream;
+using std::istringstream;
+using std::stringstream;
+using std::endl;
+using std::setprecision;
+using std::string;
+using std::left;
+using std::right;
 
 PeridigmNS::Timer& PeridigmNS::Timer::self() {
   static Timer timer;

--- a/src/core/unit_test/utPeridigm_State.cpp
+++ b/src/core/unit_test/utPeridigm_State.cpp
@@ -23,7 +23,7 @@
 
 using namespace Teuchos;
 using namespace PeridigmNS;
-using namespace std;
+using std::vector;
 
 //! Create a two-point problem for testing.
 PeridigmNS::State createTwoPointProblem(Teuchos::RCP<Epetra_Comm> comm, Teuchos::RCP<Epetra_BlockMap> &overlapScalarPointMap, Teuchos::RCP<Epetra_BlockMap> &overlapVectorPointMap, Teuchos::RCP<Epetra_BlockMap> &ownedScalarBondMap, vector<int> &scalarPointFieldIds, vector<int> &vectorPointFieldIds, vector<int> &bondFieldIds)

--- a/src/damage/Peridigm_CriticalStretchDamageModel.cpp
+++ b/src/damage/Peridigm_CriticalStretchDamageModel.cpp
@@ -48,8 +48,6 @@
 #include "Peridigm_CriticalStretchDamageModel.hpp"
 #include "Peridigm_Field.hpp"
 
-using namespace std;
-
 PeridigmNS::CriticalStretchDamageModel::CriticalStretchDamageModel(const Teuchos::ParameterList& params)
   : DamageModel(params), m_applyThermalStrains(false), m_modelCoordinatesFieldId(-1), m_coordinatesFieldId(-1), m_damageFieldId(-1), m_bondDamageFieldId(-1), m_deltaTemperatureFieldId(-1)
 {

--- a/src/damage/Peridigm_DamageModelFactory.cpp
+++ b/src/damage/Peridigm_DamageModelFactory.cpp
@@ -54,8 +54,6 @@
 #include "Peridigm_JohnsonCookDamageModel.hpp"
 #include "Peridigm_VonMisesStressDamageModel.hpp"
 
-using namespace std;
-
 Teuchos::RCP<PeridigmNS::DamageModel>
 PeridigmNS::DamageModelFactory::create(const Teuchos::ParameterList& damageModelParams)
 {

--- a/src/damage/Peridigm_InterfaceAwareDamageModel.cpp
+++ b/src/damage/Peridigm_InterfaceAwareDamageModel.cpp
@@ -48,7 +48,19 @@
 #include "Peridigm_InterfaceAwareDamageModel.hpp"
 #include "Peridigm_Field.hpp"
 
-using namespace std;
+using std::vector;
+using std::map;
+using std::pair;
+using std::copy;
+using std::cout;
+using std::ofstream;
+using std::ifstream;
+using std::istringstream;
+using std::stringstream;
+using std::endl;
+using std::setprecision;
+using std::string;
+using std::back_inserter;
 
 PeridigmNS::InterfaceAwareDamageModel::InterfaceAwareDamageModel(const Teuchos::ParameterList& params)
   : DamageModel(params), m_applyThermalStrains(false), m_modelCoordinatesFieldId(-1), m_coordinatesFieldId(-1), m_damageFieldId(-1), m_bondDamageFieldId(-1), m_criticalStretchFieldId(-1), m_deltaTemperatureFieldId(-1)

--- a/src/damage/Peridigm_JohnsonCookDamageModel.cpp
+++ b/src/damage/Peridigm_JohnsonCookDamageModel.cpp
@@ -51,8 +51,6 @@
 #include "material_utilities.h" // to use Influence Function 
 #include "correspondence.h" // to compute weighted volume
 
-using namespace std;
-
 PeridigmNS::JohnsonCookDamageModel::JohnsonCookDamageModel(const Teuchos::ParameterList& params)
   : DamageModel(params), 
     m_thresholdDamage(0.0), 

--- a/src/damage/Peridigm_UserDefinedTimeDependentCriticalStretchDamageModel.cpp
+++ b/src/damage/Peridigm_UserDefinedTimeDependentCriticalStretchDamageModel.cpp
@@ -48,7 +48,19 @@
 #include "Peridigm_UserDefinedTimeDependentCriticalStretchDamageModel.hpp"
 #include "Peridigm_Field.hpp"
 
-using namespace std;
+using std::vector;
+using std::map;
+using std::pair;
+using std::copy;
+using std::cout;
+using std::ofstream;
+using std::ifstream;
+using std::istringstream;
+using std::stringstream;
+using std::endl;
+using std::setprecision;
+using std::string;
+using std::back_inserter;
 
 PeridigmNS::UserDefinedTimeDependentCriticalStretchDamageModel::UserDefinedTimeDependentCriticalStretchDamageModel(const Teuchos::ParameterList& params)
   : DamageModel(params), m_applyThermalStrains(false), m_modelCoordinatesFieldId(-1), m_coordinatesFieldId(-1), m_damageFieldId(-1), m_bondDamageFieldId(-1), m_deltaTemperatureFieldId(-1)

--- a/src/damage/Peridigm_VonMisesStressDamageModel.cpp
+++ b/src/damage/Peridigm_VonMisesStressDamageModel.cpp
@@ -50,7 +50,7 @@
 #include "material_utilities.h" // to use Influence Function 
 #include "correspondence.h" // to compute weighted volume
 
-using namespace std;
+using std::max;
 
 PeridigmNS::VonMisesStressDamageModel::VonMisesStressDamageModel(const Teuchos::ParameterList& params)
   : DamageModel(params), 

--- a/src/io/Peridigm_OutputManager_ExodusII.cpp
+++ b/src/io/Peridigm_OutputManager_ExodusII.cpp
@@ -62,7 +62,19 @@
 #include "Peridigm_OutputManager_ExodusII.hpp"
 #include "Peridigm_Field.hpp"
 
-using namespace std;
+using std::vector;
+using std::map;
+using std::pair;
+using std::copy;
+using std::cout;
+using std::ofstream;
+using std::ifstream;
+using std::istringstream;
+using std::stringstream;
+using std::endl;
+using std::setprecision;
+using std::string;
+using std::back_inserter;
 
 PeridigmNS::OutputManager_ExodusII::OutputManager_ExodusII(const Teuchos::RCP<Teuchos::ParameterList>& params, 
                                                            PeridigmNS::Peridigm *peridigm_,

--- a/src/io/Peridigm_ProximitySearch.cpp
+++ b/src/io/Peridigm_ProximitySearch.cpp
@@ -44,13 +44,18 @@
 // ************************************************************************
 //@HEADER
 
+#include <set>
 #include <Epetra_Import.h>
 #include "Peridigm_ProximitySearch.hpp"
 #include "QuickGrid.h"
 #include "PdZoltan.h"
 #include "NeighborhoodList.h"
 
-using namespace std;
+using std::vector;
+using std::map;
+using std::pair;
+using std::cout;
+using std::set;
 
 void PeridigmNS::ProximitySearch::RebalanceNeighborhoodList(Teuchos::RCP<const Epetra_BlockMap> currentOwnedMap,     /* input  */
                                                             Teuchos::RCP<const Epetra_BlockMap> currentOverlapMap,   /* input  */

--- a/src/io/bond_volume/quick_grid/unit_test/ut_bondVolumeConvergenceStudy.cxx
+++ b/src/io/bond_volume/quick_grid/unit_test/ut_bondVolumeConvergenceStudy.cxx
@@ -88,7 +88,6 @@ const size_t myRank=0;
 double horizon;
 std::string neighborhoodType;
 std::string type;
-//using namespace std;
 
 void probe_shear
 (

--- a/src/io/discretization/Peridigm_AlbanyDiscretization.cpp
+++ b/src/io/discretization/Peridigm_AlbanyDiscretization.cpp
@@ -62,7 +62,18 @@
 #include <fstream>
 #include <set>
 
-using namespace std;
+using std::vector;
+using std::map;
+using std::pair;
+using std::set;
+using std::copy;
+using std::cout;
+using std::ofstream;
+using std::istringstream;
+using std::stringstream;
+using std::endl;
+using std::setprecision;
+using std::string;
 
 PeridigmNS::AlbanyDiscretization::AlbanyDiscretization(const MPI_Comm& mpiComm,
                                                        const Teuchos::RCP<Teuchos::ParameterList>& params,

--- a/src/io/discretization/Peridigm_DiscretizationFactory.cpp
+++ b/src/io/discretization/Peridigm_DiscretizationFactory.cpp
@@ -51,7 +51,7 @@
 #include "Peridigm_TextFileDiscretization.hpp"
 #include "Peridigm_PdQuickGridDiscretization.hpp"
 
-using namespace std;
+using std::string;
 
 PeridigmNS::DiscretizationFactory::DiscretizationFactory(const Teuchos::RCP<Teuchos::ParameterList>& discParams_) :
   discParams(discParams_)

--- a/src/io/discretization/Peridigm_ExodusDiscretization.cpp
+++ b/src/io/discretization/Peridigm_ExodusDiscretization.cpp
@@ -65,7 +65,22 @@
 #include <math.h>
 #include <exodusII.h>
 
-using namespace std;
+using std::vector;
+using std::map;
+using std::pair;
+using std::set;
+using std::copy;
+using std::cout;
+using std::ofstream;
+using std::istringstream;
+using std::stringstream;
+using std::endl;
+using std::setprecision;
+using std::string;
+using std::setfill;
+using std::setw;
+using std::logic_error;
+using std::invalid_argument;
 
 //#define DEBUGGING_BACKWARDS_COMPATIBILITY_NEIGHBORHOOD_LIST
 

--- a/src/io/discretization/Peridigm_GeometryUtils.cpp
+++ b/src/io/discretization/Peridigm_GeometryUtils.cpp
@@ -47,7 +47,9 @@
 
 #include "Peridigm_GeometryUtils.hpp"
 #include <Teuchos_Assert.hpp>
-using namespace std;
+using std::vector;
+using std::pair;
+using std::cout;
 
 void PeridigmNS::tetCentroidAndVolume(double* const nodeCoordinates,
                                       double* centroid,

--- a/src/io/discretization/Peridigm_PdQuickGridDiscretization.cpp
+++ b/src/io/discretization/Peridigm_PdQuickGridDiscretization.cpp
@@ -52,7 +52,7 @@
 #include <vector>
 #include <sstream>
 
-using namespace std;
+using std::string;
 using std::shared_ptr;
 
 PeridigmNS::PdQuickGridDiscretization::PdQuickGridDiscretization(const Teuchos::RCP<const Epetra_Comm>& epetra_comm,

--- a/src/io/discretization/Peridigm_TextFileDiscretization.cpp
+++ b/src/io/discretization/Peridigm_TextFileDiscretization.cpp
@@ -63,7 +63,21 @@
 #include <sstream>
 #include <fstream>
 
-using namespace std;
+using std::vector;
+using std::map;
+using std::pair;
+using std::set;
+using std::copy;
+using std::cout;
+using std::ofstream;
+using std::ifstream;
+using std::istringstream;
+using std::stringstream;
+using std::endl;
+using std::setprecision;
+using std::string;
+using std::istream_iterator;
+using std::back_inserter;
 
 PeridigmNS::TextFileDiscretization::TextFileDiscretization(const Teuchos::RCP<const Epetra_Comm>& epetra_comm,
                                                            const Teuchos::RCP<Teuchos::ParameterList>& params) :

--- a/src/io/discretization/unit_test/utPeridigm_GeometryUtils.cpp
+++ b/src/io/discretization/unit_test/utPeridigm_GeometryUtils.cpp
@@ -60,7 +60,7 @@
 
 using namespace Teuchos;
 using namespace PeridigmNS;
-using namespace std;
+using std::vector;
 
 //! Exercise tetVolume() and tetCentroid functions
 TEUCHOS_UNIT_TEST(GeometryUtils, TetGeometry) {

--- a/src/io/unit_test/utPeridigm_ProximitySearch.cpp
+++ b/src/io/unit_test/utPeridigm_ProximitySearch.cpp
@@ -45,7 +45,7 @@
 // ************************************************************************
 //@HEADER
 
-
+#include <set>
 #include <Epetra_ConfigDefs.h> // used to define HAVE_MPI
 #ifdef HAVE_MPI
   #include <Epetra_MpiComm.h>
@@ -60,7 +60,11 @@
 
 using namespace Teuchos;
 using namespace PeridigmNS;
-using namespace std;
+using std::vector;
+using std::map;
+using std::pair;
+using std::cout;
+using std::set;
 
 
 TEUCHOS_UNIT_TEST(ProximitySearch, TwoPointProblem) {

--- a/src/io/unit_test/utPeridigm_SearchTree.cpp
+++ b/src/io/unit_test/utPeridigm_SearchTree.cpp
@@ -56,7 +56,8 @@
 #include <sstream>
 #include <fstream>
 
-using namespace std;
+using std::vector;
+using std::string;
 using namespace PeridigmNS;
 
 //! Generate simple eight-point cube mesh

--- a/src/io/unit_test/utPeridigm_SearchTree_Performance.cpp
+++ b/src/io/unit_test/utPeridigm_SearchTree_Performance.cpp
@@ -61,7 +61,12 @@
 #include <fstream>
 
 
-using namespace std;
+using std::vector;
+using std::string;
+using std::ifstream;
+using std::cout;
+using std::endl;
+using std::istringstream;
 using namespace PeridigmNS;
 
 

--- a/src/io/utilities/Peridigm_Memstat.cpp
+++ b/src/io/utilities/Peridigm_Memstat.cpp
@@ -14,7 +14,14 @@
 #include <Teuchos_GlobalMPISession.hpp>
 #include <Teuchos_RCP.hpp>
 
-using namespace std;
+using std::vector;
+using std::map;
+using std::pair;
+using std::cout;
+using std::left;
+using std::right;
+using std::setw;
+using std::endl;
 
 PeridigmNS::Memstat * PeridigmNS::Memstat::myMemstatPtr = 0;
 Teuchos::RCP<const Epetra_Comm > PeridigmNS::Memstat::myComm;

--- a/src/materials/Peridigm_BondAssociatedCorrespondenceMaterial.cpp
+++ b/src/materials/Peridigm_BondAssociatedCorrespondenceMaterial.cpp
@@ -52,8 +52,6 @@
 #include <Teuchos_Assert.hpp>
 #include <Sacado.hpp> // for MPI_abort
 
-using namespace std;
-
 PeridigmNS::BondAssociatedCorrespondenceMaterial::BondAssociatedCorrespondenceMaterial(const Teuchos::ParameterList& params)
   : Material(params),
     m_density(0.0), 

--- a/src/materials/Peridigm_CorrespondenceMaterial.cpp
+++ b/src/materials/Peridigm_CorrespondenceMaterial.cpp
@@ -51,7 +51,7 @@
 #include "correspondence.h"
 #include <Teuchos_Assert.hpp>
 
-using namespace std;
+using std::vector;
 
 PeridigmNS::CorrespondenceMaterial::CorrespondenceMaterial(const Teuchos::ParameterList& params)
   : Material(params),

--- a/src/materials/Peridigm_ElasticBondAssociatedCorrespondenceMaterial.cpp
+++ b/src/materials/Peridigm_ElasticBondAssociatedCorrespondenceMaterial.cpp
@@ -51,8 +51,6 @@
 #include "material_utilities.h"
 #include <Teuchos_Assert.hpp>
 
-using namespace std;
-
 PeridigmNS::ElasticBondAssociatedCorrespondenceMaterial::ElasticBondAssociatedCorrespondenceMaterial(const Teuchos::ParameterList& params)
   : BondAssociatedCorrespondenceMaterial(params),
     m_vonMisesStressFieldId(-1), 

--- a/src/materials/Peridigm_ElasticCorrespondenceMaterial.cpp
+++ b/src/materials/Peridigm_ElasticCorrespondenceMaterial.cpp
@@ -51,8 +51,6 @@
 #include "material_utilities.h"
 #include <Teuchos_Assert.hpp>
 
-using namespace std;
-
 PeridigmNS::ElasticCorrespondenceMaterial::ElasticCorrespondenceMaterial(const Teuchos::ParameterList& params)
   : CorrespondenceMaterial(params),
     m_applyThermalStrains(false),

--- a/src/materials/Peridigm_ElasticHypoelasticCorrespondenceMaterial.cpp
+++ b/src/materials/Peridigm_ElasticHypoelasticCorrespondenceMaterial.cpp
@@ -51,8 +51,6 @@
 #include "material_utilities.h"
 #include <Teuchos_Assert.hpp>
 
-using namespace std;
-
 PeridigmNS::ElasticHypoelasticCorrespondenceMaterial::ElasticHypoelasticCorrespondenceMaterial(const Teuchos::ParameterList& params)
   : HypoelasticCorrespondenceMaterial(params),
     m_unrotatedRateOfDeformationFieldId(-1),

--- a/src/materials/Peridigm_ElasticMaterial.cpp
+++ b/src/materials/Peridigm_ElasticMaterial.cpp
@@ -54,7 +54,7 @@
 #include <Sacado.hpp>
 #include <cmath>
 
-using namespace std;
+using std::vector;
 
 PeridigmNS::ElasticMaterial::ElasticMaterial(const Teuchos::ParameterList& params)
   : Material(params),

--- a/src/materials/Peridigm_ElasticPlasticBondAssociatedCorrespondenceMaterial.cpp
+++ b/src/materials/Peridigm_ElasticPlasticBondAssociatedCorrespondenceMaterial.cpp
@@ -51,8 +51,6 @@
 #include "material_utilities.h"
 #include <Teuchos_Assert.hpp>
 
-using namespace std;
-
 PeridigmNS::ElasticPlasticBondAssociatedCorrespondenceMaterial::ElasticPlasticBondAssociatedCorrespondenceMaterial(const Teuchos::ParameterList& params)
   : BondAssociatedCorrespondenceMaterial(params),
     m_yieldStress(0.0),

--- a/src/materials/Peridigm_ElasticPlasticCorrespondenceMaterial.cpp
+++ b/src/materials/Peridigm_ElasticPlasticCorrespondenceMaterial.cpp
@@ -51,8 +51,6 @@
 #include "material_utilities.h"
 #include <Teuchos_Assert.hpp>
 
-using namespace std;
-
 PeridigmNS::ElasticPlasticCorrespondenceMaterial::ElasticPlasticCorrespondenceMaterial(const Teuchos::ParameterList& params)
   : CorrespondenceMaterial(params),
     m_yieldStress(0.0),

--- a/src/materials/Peridigm_ElasticPlasticHardeningMaterial.cpp
+++ b/src/materials/Peridigm_ElasticPlasticHardeningMaterial.cpp
@@ -58,7 +58,7 @@
 #include <limits>
 #include <vector>
 
-using namespace std;
+using std::vector;
 
 PeridigmNS::ElasticPlasticHardeningMaterial::ElasticPlasticHardeningMaterial(const Teuchos::ParameterList & params)
   : Material(params),

--- a/src/materials/Peridigm_ElasticPlasticHypoelasticCorrespondenceMaterial.cpp
+++ b/src/materials/Peridigm_ElasticPlasticHypoelasticCorrespondenceMaterial.cpp
@@ -51,8 +51,6 @@
 #include "material_utilities.h"
 #include <Teuchos_Assert.hpp>
 
-using namespace std;
-
 PeridigmNS::ElasticPlasticHypoelasticCorrespondenceMaterial::ElasticPlasticHypoelasticCorrespondenceMaterial(const Teuchos::ParameterList& params)
   : HypoelasticCorrespondenceMaterial(params),
     m_yieldStress(0.0),

--- a/src/materials/Peridigm_ElasticPlasticMaterial.cpp
+++ b/src/materials/Peridigm_ElasticPlasticMaterial.cpp
@@ -56,7 +56,7 @@
 #include <limits>
 #include <vector>
 
-using namespace std;
+using std::vector;
 
 PeridigmNS::ElasticPlasticMaterial::ElasticPlasticMaterial(const Teuchos::ParameterList & params)
   : Material(params),

--- a/src/materials/Peridigm_HypoelasticCorrespondenceMaterial.cpp
+++ b/src/materials/Peridigm_HypoelasticCorrespondenceMaterial.cpp
@@ -52,8 +52,6 @@
 #include <Teuchos_Assert.hpp>
 #include <Sacado.hpp> // for MPI_abort
 
-using namespace std;
-
 PeridigmNS::HypoelasticCorrespondenceMaterial::HypoelasticCorrespondenceMaterial(const Teuchos::ParameterList& params)
   : Material(params),
     m_density(0.0), m_actualHorizon(0.0),

--- a/src/materials/Peridigm_IsotropicHardeningPlasticBondAssociatedCorrespondenceMaterial.cpp
+++ b/src/materials/Peridigm_IsotropicHardeningPlasticBondAssociatedCorrespondenceMaterial.cpp
@@ -51,8 +51,6 @@
 #include "material_utilities.h"
 #include <Teuchos_Assert.hpp>
 
-using namespace std;
-
 PeridigmNS::IsotropicHardeningPlasticBondAssociatedCorrespondenceMaterial::IsotropicHardeningPlasticBondAssociatedCorrespondenceMaterial(const Teuchos::ParameterList& params)
   : BondAssociatedCorrespondenceMaterial(params),
     m_yieldStress(0.0), m_hardeningStrainConstant(0.0), m_hardeningExponent(0.0),

--- a/src/materials/Peridigm_IsotropicHardeningPlasticCorrespondenceMaterial.cpp
+++ b/src/materials/Peridigm_IsotropicHardeningPlasticCorrespondenceMaterial.cpp
@@ -51,8 +51,6 @@
 #include "material_utilities.h"
 #include <Teuchos_Assert.hpp>
 
-using namespace std;
-
 PeridigmNS::IsotropicHardeningPlasticCorrespondenceMaterial::IsotropicHardeningPlasticCorrespondenceMaterial(const Teuchos::ParameterList& params)
   : CorrespondenceMaterial(params),
     m_yieldStress(0.0), m_hardMod(0.0), 

--- a/src/materials/Peridigm_IsotropicHardeningPlasticHypoelasticCorrespondenceMaterial.cpp
+++ b/src/materials/Peridigm_IsotropicHardeningPlasticHypoelasticCorrespondenceMaterial.cpp
@@ -51,8 +51,6 @@
 #include "material_utilities.h"
 #include <Teuchos_Assert.hpp>
 
-using namespace std;
-
 PeridigmNS::IsotropicHardeningPlasticHypoelasticCorrespondenceMaterial::IsotropicHardeningPlasticHypoelasticCorrespondenceMaterial(const Teuchos::ParameterList& params)
   : HypoelasticCorrespondenceMaterial(params),
     m_yieldStress(0.0),

--- a/src/materials/Peridigm_LCMMaterial.cpp
+++ b/src/materials/Peridigm_LCMMaterial.cpp
@@ -79,8 +79,6 @@
 
 #endif
 
-using namespace std;
-
 PeridigmNS::LCMMaterial::LCMMaterial(const Teuchos::ParameterList& params)
   : Material(params)
 {

--- a/src/materials/Peridigm_Material.cpp
+++ b/src/materials/Peridigm_Material.cpp
@@ -53,7 +53,7 @@
 #include <cmath>
 #include <correspondence.h> // For the semi-Lagrangian (Hypoelastic) models
 
-using namespace std;
+using std::vector;
 
 void PeridigmNS::Material::computeJacobian(const double dt,
                                            const int numOwnedPoints,

--- a/src/materials/Peridigm_MultiphysicsElasticMaterial.cpp
+++ b/src/materials/Peridigm_MultiphysicsElasticMaterial.cpp
@@ -55,7 +55,7 @@
 #include <Sacado.hpp>
 #include <cmath>
 
-using namespace std;
+using std::vector;
 
 PeridigmNS::MultiphysicsElasticMaterial::MultiphysicsElasticMaterial(const Teuchos::ParameterList& params)
   : Material(params),

--- a/src/materials/Peridigm_Pals_Model.cpp
+++ b/src/materials/Peridigm_Pals_Model.cpp
@@ -55,7 +55,7 @@
 #include <string>
 #include <cstdio>
 
-using namespace std;
+using std::vector;
 
 using MATERIAL_EVALUATION::PALS::NUM_LAGRANGE_MULTIPLIERS;
 

--- a/src/materials/Peridigm_ViscoPlasticNeedlemanCorrespondenceMaterial.cpp
+++ b/src/materials/Peridigm_ViscoPlasticNeedlemanCorrespondenceMaterial.cpp
@@ -51,8 +51,6 @@
 #include "material_utilities.h"
 #include <Teuchos_Assert.hpp>
 
-using namespace std;
-
 PeridigmNS::ViscoplasticNeedlemanCorrespondenceMaterial::ViscoplasticNeedlemanCorrespondenceMaterial(const Teuchos::ParameterList& params)
   : CorrespondenceMaterial(params),
     m_yieldStress(0.0), m_strainHardeningExponent(0.0), m_rateHardeningExponent(0.0), m_refStrainRate(0.0), m_refStrain0(0.0), m_refStrain1(0.0),

--- a/src/materials/unit_test/twoPoint_SLS_Relaxation/twoPoint_SLS_Relaxation.cpp
+++ b/src/materials/unit_test/twoPoint_SLS_Relaxation/twoPoint_SLS_Relaxation.cpp
@@ -60,7 +60,6 @@
 
 #include <fstream>
 
-using namespace std;
 using namespace MATERIAL_EVALUATION;
 using std::shared_ptr;
 using namespace Field_NS;

--- a/src/materials/unit_test/utPeridigm_ElasticMaterial.cpp
+++ b/src/materials/unit_test/utPeridigm_ElasticMaterial.cpp
@@ -55,7 +55,7 @@
 #include <iostream>
 
 
-using namespace std;
+using std::vector;
 using namespace PeridigmNS;
 using namespace Teuchos;
 

--- a/src/materials/unit_test/utPeridigm_ElasticPlastic/utPeridigm_ElasticPlasticMaterial.cpp
+++ b/src/materials/unit_test/utPeridigm_ElasticPlastic/utPeridigm_ElasticPlasticMaterial.cpp
@@ -59,7 +59,6 @@
 
 #include <fstream>
 
-using namespace std;
 using namespace MATERIAL_EVALUATION;
 using std::shared_ptr;
 using namespace Field_NS;

--- a/src/materials/unit_test/utPeridigm_MultiphysicsElasticMaterial.cpp
+++ b/src/materials/unit_test/utPeridigm_MultiphysicsElasticMaterial.cpp
@@ -54,7 +54,6 @@
 #include "Peridigm_Field.hpp"
 #include <Epetra_SerialComm.h>
 
-using namespace std;
 using namespace PeridigmNS;
 using namespace Teuchos;
 


### PR DESCRIPTION
Further changes to the PR #349 needed to build and pass the tests with Trilinos14. 

commit fe1ff1c02780d7e1aa162565df392443212819f4: modified Trilinos_BINARY_PATH so that it finds exodiff and epu. all tests pass.

commit 6425195bda4a4c97ca964e08fbdd5a7556054c34: added function to find yaml

commit a4b779263539b1ff3242ec243d9442b01bce5e50 Merge: 780fdef4 82c6ad8f Author: Patrick Diehl <diehlpk@users.noreply.github.com> Date: Thu Aug 3 20:50:58 2023 -0500

    Merge branch 'master' into master

commit 780fdef46a02acf159a66bfef541fce86e1c8ad8 Author: Christian Glusa <caglusa@sandia.gov> Date: Thu Aug 3 14:29:09 2023 -0600

    update CMake logic

commit 0b8000088aa3610c91cf1f56d1c19a44e4f521aa Author: Christian Glusa <caglusa@sandia.gov> Date: Thu Aug 3 14:27:10 2023 -0600

    Don't do 'using namespace std'